### PR TITLE
Tool to check DT_SYMTAB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,15 @@ add_executable(
   utils.cc
   )
 
+add_executable(
+  print_dynsymtab
+  print_dynsymtab.cc
+  elf_binary.cc
+  hash.cc
+  ldsoconf.cc
+  utils.cc
+  )
+
 add_subdirectory(tests)
 
 foreach(t exe hash)

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -7,6 +7,8 @@
 #include <unistd.h>
 
 #include <cstring>
+#include <numeric>
+#include <sstream>
 
 ELFBinary::ELFBinary(const std::string& filename, int fd, char* head, size_t size)
     : filename_(filename), fd_(fd), head_(head), size_(size) {
@@ -68,9 +70,11 @@ void ELFBinary::ReadDynSymtab() {
             for (Elf_Sym* sym = &symtab_[n];; ++sym) {
                 uint32_t h2 = *hv++;
                 const std::string name(strtab_ + sym->st_name);
-                // LOGF("%s@%s\n", name.c_str(), name_.c_str());
                 // TODO(hamaji): Handle version symbols.
-                CHECK(syms_.emplace(name, sym).second);
+
+                nsyms_++;
+                LOGF("%s@%s index in .dynsymtab = %ld\n", name.c_str(), name_.c_str(), sym - symtab_);
+                CHECK(syms_.emplace(std::make_pair(name, sym - symtab_), sym).second);
                 if (h2 & 1) break;
             }
         }
@@ -78,7 +82,10 @@ void ELFBinary::ReadDynSymtab() {
             Elf_Sym* sym = &symtab_[n];
             if (sym->st_name) {
                 const std::string name(strtab_ + sym->st_name);
-                CHECK(syms_.emplace(name, sym).second);
+
+                nsyms_++;
+                LOGF("%s@%s index in .dynsymtab = %ld\n", name.c_str(), name_.c_str(), sym - symtab_);
+                CHECK(syms_.emplace(std::make_pair(name, sym - symtab_), sym).second);
             }
         }
     } else {
@@ -89,9 +96,13 @@ void ELFBinary::ReadDynSymtab() {
             Elf_Sym* sym = &symtab_[n];
             if (sym->st_name == 0) continue;
             const std::string name(strtab_ + sym->st_name);
-            CHECK(syms_.emplace(name, sym).second);
+
+            nsyms_++;
+            LOGF("%s@%s index in .dynsymtab = %ld\n", name.c_str(), name_.c_str(), sym - symtab_);
+            CHECK(syms_.emplace(std::make_pair(name, sym - symtab_), sym).second);
         }
     }
+    LOGF("nsyms_ = %d\n", nsyms_);
 }
 
 Elf_Phdr* ELFBinary::FindPhdr(uint64_t type) {
@@ -109,6 +120,35 @@ const Elf_Phdr& ELFBinary::GetPhdr(uint64_t type) {
     return *phdr;
 }
 
+void ELFBinary::PrintVersyms() {
+    CHECK(versym_);
+    CHECK(nsyms_);
+
+    for (int i = 0; i < nsyms_ + 1; i++) {
+        if (versym_[i] == VER_NDX_LOCAL) {
+            LOGF("VERSYM: VER_NDX_LOCAL\n");
+        } else if (versym_[i] == VER_NDX_GLOBAL) {
+            LOGF("VERSYM: VER_NDX_GLOBAL\n");
+        } else {
+            LOGF("VERSYM: %d\n", versym_[i]);
+        }
+    }
+}
+
+void ELFBinary::PrintVerneeds() {
+    CHECK(verneed_);
+    Elf_Verneed* vn = verneed_;
+    for (int i = 0; i < verneednum_; ++i) {
+        LOGF("VERNEED: ver=%d cnt=%d file=%s aux=%d next=%d\n", vn->vn_version, vn->vn_cnt, strtab_ + vn->vn_file, vn->vn_aux, vn->vn_next);
+        Elf_Vernaux* vna = (Elf_Vernaux*)((char*)vn + vn->vn_aux);
+        for (int j = 0; j < vn->vn_cnt; ++j) {
+            LOGF(" VERNAUX: hash=%d flags=%d other=%d name=%s next=%d\n", vna->vna_hash, vna->vna_flags, vna->vna_other,
+                 strtab_ + vna->vna_name, vna->vna_next);
+            vna = (Elf_Vernaux*)((char*)vna + vna->vna_next);
+        }
+        vn = (Elf_Verneed*)((char*)vn + vn->vn_next);
+    }
+}
 void ELFBinary::ParsePhdrs() {
     for (int i = 0; i < ehdr_->e_phnum; ++i) {
         Elf_Phdr* phdr = reinterpret_cast<Elf_Phdr*>(head_ + ehdr_->e_phoff + ehdr_->e_phentsize * i);
@@ -180,6 +220,12 @@ void ELFBinary::ParseDynamic(size_t off, size_t size) {
             init_ = dyn->d_un.d_ptr;
         } else if (dyn->d_tag == DT_FINI) {
             fini_ = dyn->d_un.d_ptr;
+        } else if (dyn->d_tag == DT_VERSYM) {
+            versym_ = reinterpret_cast<Elf_Versym*>(get_ptr());
+        } else if (dyn->d_tag == DT_VERNEED) {
+            verneed_ = reinterpret_cast<Elf_Verneed*>(get_ptr());
+        } else if (dyn->d_tag == DT_VERNEEDNUM) {
+            verneednum_ = dyn->d_un.d_val;
         }
     }
     CHECK(strtab_);

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -43,7 +43,7 @@ public:
     const std::vector<uintptr_t>& init_array() const { return init_array_; }
     const std::vector<uintptr_t>& fini_array() const { return fini_array_; }
 
-    const std::map<std::string, Elf_Sym*>& GetSymbolMap() const { return syms_; }
+    const std::map<std::pair<std::string, int>, Elf_Sym*>& GetSymbolMap() const { return syms_; }
 
     Range GetRange() const;
 
@@ -59,7 +59,9 @@ public:
 
     const Elf_Phdr& GetPhdr(uint64_t type);
 
-    void parse_version();
+    void PrintVerneeds();
+
+    void PrintVersyms();
 
 private:
     void ParsePhdrs();

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -63,6 +63,10 @@ public:
 
     void PrintVersyms();
 
+    std::string ShowDynSymtab();
+
+    std::string ShowVersym(int index);
+
 private:
     void ParsePhdrs();
 
@@ -103,7 +107,14 @@ private:
     std::vector<uintptr_t> fini_array_;
 
     std::string name_;
-    std::map<std::string, Elf_Sym*> syms_;
+    // Map from (symbol, offset in .dynsymtab) to Elf_Sym*
+    std::map<std::pair<std::string, int>, Elf_Sym*> syms_;
+
+    int nsyms_{0};
+
+    Elf_Versym* versym_{nullptr};
+    Elf_Verneed* verneed_{nullptr};
+    Elf_Word verneednum_{0};
 };
 
 std::unique_ptr<ELFBinary> ReadELF(const std::string& filename);

--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -1,0 +1,14 @@
+#include "elf_binary.h"
+
+#include <iostream>
+
+int main(int argc, const char* argv[]) {
+    if (argc != 2) {
+        std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program parse DT_SYMTAB of the given ELF file." << std::endl;
+        return 1;
+    }
+
+    auto b = ReadELF(argv[1]);
+    b->ReadDynSymtab();
+    std::cout << b->ShowDynSymtab();
+}

--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -1,3 +1,13 @@
+//
+// print_dynsymtab
+//
+// This program parses and prints DT_SYMTAB of a given ELF file. It prints all symbols
+// and version information. When the ELF file does not include version information,
+// it prints NO_VERSION_INFO instead of version information.
+//
+// Unlike nm -D --with-symbol-versions or readelf --dynsyms, it works without any shdrs
+// because print_dynsymtab gets all information only from phdrs.
+
 #include "elf_binary.h"
 
 #include <iostream>


### PR DESCRIPTION
`print_dynsymtab` command parses and prints DT_SYMTAB of a given ELF file.  This command will be very useful when we build VERSYM.

Following is an example of the output.
```
> ./print_dynsymtab tests/test_exe
1: _Z14lib_use_stderrv VER_NDX_LOCAL
2: _Z19lib_base_init_valuev VER_NDX_LOCAL
3: _Z20in_both_lib_and_basev VER_NDX_LOCAL
4: abort GLIBC_2.2.5 (2)
5: _Z14lib_thread_varv VER_NDX_LOCAL
6: _Z19lib_add_42_via_basei VER_NDX_LOCAL
7: _Z25lib_base_thread_var_relocv VER_NDX_LOCAL
8: _Z20lib_thread_var_relocv VER_NDX_LOCAL
9: _Z11lib_base_vfv VER_NDX_LOCAL
10: _Z15lib_base_globalv VER_NDX_LOCAL
11: puts GLIBC_2.2.5 (2)
12: _Z14lib_init_valuev VER_NDX_LOCAL
13: _ITM_deregisterTMCloneTable VER_NDX_LOCAL
14: _Z19lib_base_thread_varv VER_NDX_LOCAL
15: __libc_start_main GLIBC_2.2.5 (2)
16: __gmon_start__ VER_NDX_LOCAL
17: _ITM_registerTMCloneTable VER_NDX_LOCAL
18: fwrite GLIBC_2.2.5 (2)
19: _edata VER_NDX_GLOBAL
20: __cxa_finalize GLIBC_2.2.5 (2)
21: __data_start VER_NDX_GLOBAL
22: _end VER_NDX_GLOBAL
23: data_start VER_NDX_GLOBAL
24: _IO_stdin_used VER_NDX_GLOBAL
25: main VER_NDX_GLOBAL
26: _start VER_NDX_GLOBAL
27: stderr GLIBC_2.2.5 (2)
28: __bss_start VER_NDX_GLOBAL
29: __libc_csu_init VER_NDX_GLOBAL
30: __libc_csu_fini VER_NDX_GLOBAL
```