### PR TITLE
Bugfix for gnu_hash_ containing no symbols 

### DIFF
--- a/sold.cc
+++ b/sold.cc
@@ -320,16 +320,18 @@ private:
     void EmitGnuHash(FILE* fp) {
         CHECK(ftell(fp) == GnuHashOffset());
         const Elf_GnuHash& gnu_hash = syms_.gnu_hash();
+        const std::vector<std::string>& sym_names = syms_.GetNames();
+
         Write(fp, gnu_hash.nbuckets);
         Write(fp, gnu_hash.symndx);
         Write(fp, gnu_hash.maskwords);
         Write(fp, gnu_hash.shift2);
         Elf_Addr bloom_filter = -1;
         Write(fp, bloom_filter);
-        uint32_t bucket = gnu_hash.symndx;
+        // If there is no symbols in gnu_hash_, bucket must be 0.
+        uint32_t bucket = (sym_names.size() > gnu_hash.symndx) ? gnu_hash.symndx : 0;
         Write(fp, bucket);
 
-        const std::vector<std::string>& sym_names = syms_.GetNames();
         for (size_t i = gnu_hash.symndx; i < sym_names.size(); ++i) {
             uint32_t h = CalcGnuHash(sym_names[i]) & ~1;
             if (i == sym_names.size() - 1) {

--- a/tests/hello-g++/test.sh
+++ b/tests/hello-g++/test.sh
@@ -2,4 +2,5 @@
 
 g++ hello.cc -o hello
 ../../build/sold hello hello.out
+../../build/print_dynsymtab hello.out
 ./hello.out

--- a/tests/hello-gcc/test.sh
+++ b/tests/hello-gcc/test.sh
@@ -2,4 +2,5 @@
 
 gcc hello.c -o hello
 ../../build/sold hello hello.out
+../../build/print_dynsymtab hello.out
 ./hello.out

--- a/tests/just-return-g++/test.sh
+++ b/tests/just-return-g++/test.sh
@@ -2,4 +2,5 @@
 
 g++ return.cc -o return
 ../../build/sold return return.out
+../../build/print_dynsymtab return.out
 ./return.out

--- a/tests/just-return-gcc/test.sh
+++ b/tests/just-return-gcc/test.sh
@@ -2,4 +2,5 @@
 
 gcc return.c -o return
 ../../build/sold return return.out
+../../build/print_dynsymtab return.out
 ./return.out

--- a/tests/simple-lib-g++/test.sh
+++ b/tests/simple-lib-g++/test.sh
@@ -5,4 +5,5 @@ g++ -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -o libmax.so libmax.o
 g++ -Wl,--hash-style=gnu -o main main.cc libmax.so
 
 LD_LIBRARY_PATH=. ../../build/sold main main.out
+../../build/print_dynsymtab main.out
 LD_LIBRARY_PATH=. ./main.out

--- a/tests/simple-lib-gcc/test.sh
+++ b/tests/simple-lib-gcc/test.sh
@@ -5,4 +5,5 @@ gcc -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -o libmax.so libmax.o
 gcc -Wl,--hash-style=gnu -o main main.c libmax.so
 
 LD_LIBRARY_PATH=. ../../build/sold main main.out
+../../build/print_dynsymtab main.out
 LD_LIBRARY_PATH=. ./main.out


### PR DESCRIPTION
If there is no symbols for `gnu_hash_`, we should set `bucket` to 0 in order to show the `gnu_hash_` containing no valid symbols. Without this bugfix, `print_dynsymtab` doesn't works.