### PR TITLE
Emit section headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ add_subdirectory(tests)
 foreach(t exe hash)
   add_custom_command(
     OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/tests/test_${t}_out"
-    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/sold" "${CMAKE_CURRENT_BINARY_DIR}/tests/test_${t}" -o "${CMAKE_CURRENT_BINARY_DIR}/tests/test_${t}_out"
+    COMMAND "${CMAKE_CURRENT_BINARY_DIR}/sold" "${CMAKE_CURRENT_BINARY_DIR}/tests/test_${t}" -o "${CMAKE_CURRENT_BINARY_DIR}/tests/test_${t}_out"  --section-headers 
     DEPENDS sold test_${t}
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(
   ldsoconf.cc
   strtab_builder.cc
   symtab_builder.cc
+  shdr_builder.cc
   utils.cc
   version_builder.cc
   )

--- a/shdr_builder.cc
+++ b/shdr_builder.cc
@@ -100,6 +100,12 @@ void ShdrBuilder::RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uin
         case Dynsym:
             shdr.sh_type = SHT_DYNSYM;
             shdr.sh_flags = SHF_ALLOC;
+
+            // TODO(akawashiro) Now, I assume the last local symbol is located at index 0.
+            // ref: https://www.sco.com/developers/gabi/1998-04-29/ch4.sheader.html#sh_link
+            // "One greater than the symbol table index of the last local symbol (binding STB_LOCAL)."
+            shdr.sh_info = 1;
+
             break;
         case GnuVersion:
             shdr.sh_type = SHT_GNU_versym;

--- a/shdr_builder.cc
+++ b/shdr_builder.cc
@@ -1,0 +1,147 @@
+#include "shdr_builder.h"
+
+#include <elf.h>
+#include "utils.h"
+
+void ShdrBuilder::EmitShstrtab(FILE* fp) {
+    std::string str = "";
+    str += '\0';
+    for (const auto& i : type_to_str) {
+        str += i.second;
+        str += '\0';
+    }
+
+    CHECK(fwrite(str.c_str(), str.size(), 1, fp) == 1);
+}
+
+uintptr_t ShdrBuilder::ShstrtabSize() const {
+    std::string str = "";
+    str += '\0';
+    for (const auto& i : type_to_str) {
+        str += i.second;
+        str += '\0';
+    }
+    return str.size();
+}
+
+uint32_t ShdrBuilder::GetShName(ShdrType type) const {
+    // The head of shstrtab is '\0' so we must skip it.
+    uint32_t r = 1;
+    for (const auto& i : type_to_str) {
+        if (i.first == type) {
+            break;
+        } else {
+            r += i.second.size() + 1;
+        }
+    }
+    return r;
+}
+
+void ShdrBuilder::EmitShdrs(FILE* fp) {
+    LOGF("EmitShdrs\n");
+
+    Elf_Shdr shstrtab;
+    bool found_shstrtab = false;
+    int num_not_shstrtab = 0;
+
+    // Emit other than shstrtab
+    for (const auto& s : shdrs) {
+        if (s.sh_name == GetShName(Shstrtab)) {
+            shstrtab = s;
+            found_shstrtab = true;
+        } else {
+            num_not_shstrtab++;
+            CHECK(fwrite(&s, sizeof(s), 1, fp) == 1);
+        }
+    }
+
+    // num_not_shstrtab must not be 0 because ehdr_.e_shstrndx is ignored when it is 0
+    CHECK(found_shstrtab);
+    CHECK(num_not_shstrtab != 0);
+
+    CHECK(fwrite(&shstrtab, sizeof(shstrtab), 1, fp) == 1);
+}
+
+uint32_t ShdrBuilder::GetIndex(ShdrType type) const {
+    uint32_t r = 0;
+    for (const auto& s : shdrs) {
+        if (s.sh_name == GetShName(type)) {
+            return r;
+        }
+        r++;
+    }
+
+    LOGF("It is not in shdrs.\n");
+    exit(1);
+}
+
+void ShdrBuilder::Freeze() {
+    for (auto& s : shdrs) {
+        if (s.sh_name == GetShName(GnuHash) || s.sh_name == GetShName(GnuVersion)) {
+            s.sh_link = GetIndex(Dynsym);
+        } else if (s.sh_name == GetShName(Dynsym) || s.sh_name == GetShName(GnuVersionR) || s.sh_name == GetShName(Dynamic)) {
+            s.sh_link = GetIndex(Dynstr);
+        }
+    }
+}
+
+void ShdrBuilder::RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uint64_t entsize) {
+    Elf_Shdr shdr = {0};
+    shdr.sh_name = GetShName(type);
+    shdr.sh_offset = offset;
+    shdr.sh_addr = offset;
+    shdr.sh_size = size;
+    shdr.sh_entsize = entsize;
+    switch (type) {
+        case GnuHash:
+            shdr.sh_type = SHT_GNU_HASH;
+            shdr.sh_flags = SHF_ALLOC;
+            break;
+        case Dynsym:
+            shdr.sh_type = SHT_DYNSYM;
+            shdr.sh_flags = SHF_ALLOC;
+            break;
+        case GnuVersion:
+            shdr.sh_type = SHT_GNU_versym;
+            shdr.sh_flags = SHF_ALLOC;
+            break;
+        case GnuVersionR:
+            shdr.sh_type = SHT_GNU_verneed;
+            shdr.sh_flags = SHF_ALLOC;
+            break;
+        case Dynstr:
+            shdr.sh_type = SHT_STRTAB;
+            shdr.sh_flags = SHF_ALLOC;
+            break;
+        case RelaDyn:
+            shdr.sh_type = SHT_RELA;
+            shdr.sh_flags = SHF_ALLOC;
+            break;
+        case Init:
+            shdr.sh_type = SHT_INIT_ARRAY;
+            shdr.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+            break;
+        case Fini:
+            shdr.sh_type = SHT_FINI_ARRAY;
+            shdr.sh_flags = SHF_ALLOC | SHF_EXECINSTR;
+            break;
+        case Strtab:
+            shdr.sh_type = SHT_STRTAB;
+            shdr.sh_flags = 0;
+            shdr.sh_addr = 0;
+            break;
+        case Shstrtab:
+            shdr.sh_type = SHT_STRTAB;
+            shdr.sh_flags = 0;
+            shdr.sh_addr = 0;
+            break;
+        case Dynamic:
+            shdr.sh_type = SHT_DYNAMIC;
+            shdr.sh_flags = SHF_ALLOC | SHF_WRITE;
+            break;
+        default:
+            LOGF("Not implemented\n");
+            exit(1);
+    }
+    shdrs.push_back(shdr);
+}

--- a/shdr_builder.h
+++ b/shdr_builder.h
@@ -1,0 +1,39 @@
+#include <map>
+#include <string>
+#include <vector>
+
+#include "utils.h"
+
+class ShdrBuilder {
+public:
+    enum ShdrType { GnuHash, Dynsym, GnuVersion, GnuVersionR, Dynstr, RelaDyn, Init, Fini, Strtab, Shstrtab, Dynamic, Text, TLS };
+    void EmitShstrtab(FILE* fp);
+    void EmitShdrs(FILE* fp);
+    uintptr_t ShstrtabSize() const;
+    Elf_Half CountShdrs() const { return shdrs.size(); }
+    void RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uint64_t entsize = 0);
+    Elf_Half Shstrndx() const { return shdrs.size() - 1; }
+
+    // After register all shdrs, you must call Freeze.
+    void Freeze();
+
+private:
+    const std::map<ShdrType, std::string> type_to_str = {{GnuHash, ".gnu.hash"},
+                                                         {Dynsym, ".dynsym"},
+                                                         {GnuVersion, ".gnu.version"},
+                                                         {GnuVersionR, ".gnu.version_r"},
+                                                         {Dynstr, ".dynstr"},
+                                                         {RelaDyn, ".rela.dyn"},
+                                                         {Init, ".init"},
+                                                         {Fini, ".fini"},
+                                                         {Strtab, ".strtab"},
+                                                         {Shstrtab, ".shstrtab"},
+                                                         {Dynamic, ".dynamic"},
+                                                         {Text, ".text"},
+                                                         {TLS, ".tls"}};
+
+    // The first section header must be NULL.
+    std::vector<Elf_Shdr> shdrs = {Elf_Shdr{0}};
+    uint32_t GetShName(ShdrType type) const;
+    uint32_t GetIndex(ShdrType type) const;
+};

--- a/sold.cc
+++ b/sold.cc
@@ -36,7 +36,8 @@
 
 class Sold {
 public:
-    Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos) : exclude_sos_(exclude_sos) {
+    Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, bool emit_section_header)
+        : exclude_sos_(exclude_sos), emit_section_header_(emit_section_header) {
         main_binary_ = ReadELF(elf_filename);
         is_executable_ = main_binary_->FindPhdr(PT_INTERP);
         link_binaries_.push_back(main_binary_.get());
@@ -133,7 +134,7 @@ private:
         EmitCode(fp);
         EmitTLS(fp);
 
-        EmitShdr(fp);
+        if (emit_section_header_) EmitShdr(fp);
 
         fclose(fp);
     }
@@ -858,6 +859,7 @@ private:
     uintptr_t tls_file_offset_{0};
     uintptr_t tls_offset_{0};
     bool is_executable_{false};
+    bool emit_section_header_;
 
     uintptr_t interp_offset_;
     SymtabBuilder syms_;
@@ -880,6 +882,7 @@ Options:
 -o, --output-file OUTPUT_FILE   Specify the ELF file to output (this option is mandatory)
 -i, --input-file INPUT_FILE     Specify the ELF file to output
 -e, --exclude-so EXCLUDE_FILE   Specify the ELF file to exclude (e.g. libmax.so) 
+--section-headers               Emit section headers
 
 The last argument is interpreted as SOURCE_FILE when -i option isn't given.
 )" << std::endl;
@@ -891,16 +894,21 @@ int main(int argc, char* const argv[]) {
         {"input-file", required_argument, nullptr, 'i'},
         {"output-file", required_argument, nullptr, 'o'},
         {"exclude-so", required_argument, nullptr, 'e'},
+        {"section-headers", no_argument, nullptr, 1},
         {0, 0, 0, 0},
     };
 
     std::string input_file;
     std::string output_file;
     std::vector<std::string> exclude_sos;
+    bool emit_section_header = false;
 
     int opt;
     while ((opt = getopt_long(argc, argv, "hi:o:e:", long_options, nullptr)) != -1) {
         switch (opt) {
+            case 1:
+                emit_section_header = true;
+                break;
             case 'e':
                 exclude_sos.push_back(optarg);
                 break;
@@ -928,6 +936,6 @@ int main(int argc, char* const argv[]) {
         return 1;
     }
 
-    Sold sold(input_file, exclude_sos);
+    Sold sold(input_file, exclude_sos, emit_section_header);
     sold.Link(output_file);
 }

--- a/tests/hello-g++/test.sh
+++ b/tests/hello-g++/test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
 g++ hello.cc -o hello
-../../build/sold hello -o hello.out
+../../build/sold hello -o hello.out --section-headers
 ../../build/print_dynsymtab hello.out
 ./hello.out

--- a/tests/hello-gcc/test.sh
+++ b/tests/hello-gcc/test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
 gcc hello.c -o hello
-../../build/sold hello -o hello.out
+../../build/sold hello -o hello.out --section-headers 
 ../../build/print_dynsymtab hello.out
 ./hello.out

--- a/tests/just-return-g++/test.sh
+++ b/tests/just-return-g++/test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
 g++ return.cc -o return
-../../build/sold return -o return.out
+../../build/sold return -o return.out --section-headers
 ../../build/print_dynsymtab return.out
 ./return.out

--- a/tests/just-return-gcc/test.sh
+++ b/tests/just-return-gcc/test.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
 gcc return.c -o return
-../../build/sold return -o return.out
+../../build/sold return -o return.out --section-headers
 ../../build/print_dynsymtab return.out
 ./return.out

--- a/tests/simple-lib-g++/test.sh
+++ b/tests/simple-lib-g++/test.sh
@@ -4,6 +4,6 @@ g++ -fPIC -c -o libmax.o libmax.cc
 g++ -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -o libmax.so libmax.o
 g++ -Wl,--hash-style=gnu -o main main.cc libmax.so
 
-LD_LIBRARY_PATH=. ../../build/sold main -o main.out
+LD_LIBRARY_PATH=. ../../build/sold main -o main.out --section-headers
 ../../build/print_dynsymtab main.out
 LD_LIBRARY_PATH=. ./main.out

--- a/tests/simple-lib-gcc/test.sh
+++ b/tests/simple-lib-gcc/test.sh
@@ -4,6 +4,6 @@ gcc -fPIC -c -o libmax.o libmax.c
 gcc -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -o libmax.so libmax.o
 gcc -Wl,--hash-style=gnu -o main main.c libmax.so
 
-LD_LIBRARY_PATH=. ../../build/sold main -o main.out
+LD_LIBRARY_PATH=. ../../build/sold main -o main.out --section-headers
 ../../build/print_dynsymtab main.out
 LD_LIBRARY_PATH=. ./main.out

--- a/tests/version-gcc/test.sh
+++ b/tests/version-gcc/test.sh
@@ -10,9 +10,9 @@ gcc -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -Wl,--version-script,libm
 ln -sf libmax.so.2 libmax.so
 gcc -Wl,--hash-style=gnu -o vertest2 vertest2.c libmax.so
 
-LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest1.out vertest1 
+LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest1.out vertest1 --section-headers 
 ../../build/print_dynsymtab vertest1.out
 LD_LIBRARY_PATH=. ./vertest1.out
-LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest2.out vertest2 
+LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest2.out vertest2  --section-headers
 ../../build/print_dynsymtab vertest2.out
 LD_LIBRARY_PATH=. ./vertest2.out

--- a/utils.h
+++ b/utils.h
@@ -12,6 +12,9 @@
 #define Elf_Dyn Elf64_Dyn
 #define Elf_Addr Elf64_Addr
 #define Elf_Sym Elf64_Sym
+#define Elf_Shdr Elf64_Shdr
+#define Elf_Off Elf64_Off
+#define Elf_Half Elf64_Half
 #define Elf_Versym Elf64_Versym
 #define Elf_Word Elf64_Xword
 #define Elf_Vernaux Elf64_Vernaux

--- a/version_builder.cc
+++ b/version_builder.cc
@@ -52,7 +52,7 @@ void VersionBuilder::EmitVerneed(FILE* fp, StrtabBuilder& strtab) {
         n_verneed++;
 
         Elf_Verneed v;
-        v.vn_version = 1;
+        v.vn_version = VER_NEED_CURRENT;
         v.vn_cnt = m1.second.size();
         v.vn_file = strtab.GetPos(m1.first);
         v.vn_aux = sizeof(Elf_Verneed);
@@ -66,7 +66,7 @@ void VersionBuilder::EmitVerneed(FILE* fp, StrtabBuilder& strtab) {
 
             Elf_Vernaux a;
             a.vna_hash = CalcHash(m2.first);
-            a.vna_flags = 0;  // TODO(akawashiro) check formal document
+            a.vna_flags = VER_FLG_WEAK;
             a.vna_other = m2.second;
             a.vna_name = strtab.GetPos(m2.first);
             a.vna_next = (n_vernaux == m1.second.size()) ? 0 : sizeof(Elf_Vernaux);


### PR DESCRIPTION
Emit section headers with `--section-headers` option.

After merging the PR, we can see symbols using `readelf`.
```
% readelf -s tests/hello-gcc/hello.out
Symbol table '.dynsym' contains 7 entries:
  番号:      値         サイズ タイプ  Bind   Vis      索引名
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
     2: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __libc_start_main@GLIBC_2.2.5 (2)
     3: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     4: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
     5: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize@GLIBC_2.2.5 (2)
     6: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND puts@GLIBC_2.2.5 (2)
```