### PR TITLE
Fix sh_info to use objdump -d

### DIFF
--- a/elf_binary.h
+++ b/elf_binary.h
@@ -117,7 +117,7 @@ private:
 
     Elf_Versym* versym_{nullptr};
     Elf_Verneed* verneed_{nullptr};
-    Elf_Word verneednum_{0};
+    Elf_Xword verneednum_{0};
 };
 
 std::unique_ptr<ELFBinary> ReadELF(const std::string& filename);

--- a/shdr_builder.cc
+++ b/shdr_builder.cc
@@ -85,13 +85,14 @@ void ShdrBuilder::Freeze() {
     }
 }
 
-void ShdrBuilder::RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uint64_t entsize) {
+void ShdrBuilder::RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uint64_t entsize, Elf_Word info) {
     Elf_Shdr shdr = {0};
     shdr.sh_name = GetShName(type);
     shdr.sh_offset = offset;
     shdr.sh_addr = offset;
     shdr.sh_size = size;
     shdr.sh_entsize = entsize;
+    shdr.sh_info = info;
     switch (type) {
         case GnuHash:
             shdr.sh_type = SHT_GNU_HASH;

--- a/shdr_builder.h
+++ b/shdr_builder.h
@@ -11,7 +11,7 @@ public:
     void EmitShdrs(FILE* fp);
     uintptr_t ShstrtabSize() const;
     Elf_Half CountShdrs() const { return shdrs.size(); }
-    void RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uint64_t entsize = 0);
+    void RegisterShdr(Elf_Off offset, uint64_t size, ShdrType type, uint64_t entsize = 0, Elf_Word info = 0);
     Elf_Half Shstrndx() const { return shdrs.size() - 1; }
 
     // After register all shdrs, you must call Freeze.

--- a/sold.cc
+++ b/sold.cc
@@ -72,7 +72,7 @@ public:
         shdr_.RegisterShdr(GnuHashOffset(), GnuHashSize(), ShdrBuilder::ShdrType::GnuHash);
         shdr_.RegisterShdr(SymtabOffset(), SymtabSize(), ShdrBuilder::ShdrType::Dynsym, sizeof(Elf_Sym));
         shdr_.RegisterShdr(VersymOffset(), VersymSize(), ShdrBuilder::ShdrType::GnuVersion, sizeof(Elf_Versym));
-        shdr_.RegisterShdr(VerneedOffset(), VerneedSize(), ShdrBuilder::ShdrType::GnuVersionR);
+        shdr_.RegisterShdr(VerneedOffset(), VerneedSize(), ShdrBuilder::ShdrType::GnuVersionR, 0, version_.NumVerneed());
         shdr_.RegisterShdr(RelOffset(), RelSize(), ShdrBuilder::ShdrType::RelaDyn, sizeof(Elf_Rel));
         shdr_.RegisterShdr(InitArrayOffset(), InitArraySize(), ShdrBuilder::ShdrType::Init);
         shdr_.RegisterShdr(FiniArrayOffset(), FiniArraySize(), ShdrBuilder::ShdrType::Fini);

--- a/utils.h
+++ b/utils.h
@@ -16,7 +16,8 @@
 #define Elf_Off Elf64_Off
 #define Elf_Half Elf64_Half
 #define Elf_Versym Elf64_Versym
-#define Elf_Word Elf64_Xword
+#define Elf_Xword Elf64_Xword
+#define Elf_Word Elf64_Word
 #define Elf_Vernaux Elf64_Vernaux
 #define Elf_Verneed Elf64_Verneed
 #define ELF_ST_BIND(val) ELF64_ST_BIND(val)
@@ -91,6 +92,7 @@ struct TLS {
     std::map<ELFBinary*, size_t> bin_to_index;
     uintptr_t filesz{0};
     uintptr_t memsz{0};
+    Elf_Xword align{0};
 };
 
 bool is_special_ver_ndx(Elf64_Versym v);


### PR DESCRIPTION
`objdump -d` complains about wrong value of `sh_info` of `.gnu_version.r` section.
ref. [https://docs.oracle.com/cd/E19683-01/816-1386/6m7qcoblj/index.html#chapter6-47976](https://docs.oracle.com/cd/E19683-01/816-1386/6m7qcoblj/index.html#chapter6-47976)