### PR TITLE
Soname different from the name on the filesystem

### DIFF
--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -196,7 +196,7 @@ std::pair<std::string, std::string> ELFBinary::GetVersion(int index) {
                 Elf_Verdaux* vda = (Elf_Verdaux*)((char*)vd + vd->vd_aux);
                 for (int j = 0; j < vd->vd_cnt; ++j) {
                     if (vd->vd_flags & VER_FLG_BASE) {
-                        soname = std::string(strtab_ + vda->vda_name);
+                        soname = name();
                     }
                     if (vd->vd_ndx == versym_[index]) {
                         version = std::string(strtab_ + vda->vda_name);
@@ -354,7 +354,7 @@ void ELFBinary::ParseDynamic(size_t off, size_t size) {
             const char* needed = strtab_ + dyn->d_un.d_val;
             neededs_.push_back(needed);
         } else if (dyn->d_tag == DT_SONAME) {
-            name_ = soname_ = strtab_ + dyn->d_un.d_val;
+            soname_ = strtab_ + dyn->d_un.d_val;
         } else if (dyn->d_tag == DT_RUNPATH) {
             runpath_ = strtab_ + dyn->d_un.d_val;
         } else if (dyn->d_tag == DT_RPATH) {

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -156,7 +156,7 @@ const Elf_Phdr& ELFBinary::GetPhdr(uint64_t type) {
     return *phdr;
 }
 
-// GetVerneed returns (soname, version)
+// GetVerneed returns (filename, version)
 std::pair<std::string, std::string> ELFBinary::GetVersion(int index) {
     LOG(INFO) << "GetVerneed";
     if (!versym_) {
@@ -191,12 +191,12 @@ std::pair<std::string, std::string> ELFBinary::GetVersion(int index) {
         }
         if (verdef_) {
             Elf_Verdef* vd = verdef_;
-            std::string soname, version;
+            std::string filename, version;
             for (int i = 0; i < verdefnum_; ++i) {
                 Elf_Verdaux* vda = (Elf_Verdaux*)((char*)vd + vd->vd_aux);
                 for (int j = 0; j < vd->vd_cnt; ++j) {
                     if (vd->vd_flags & VER_FLG_BASE) {
-                        soname = name();
+                        filename = name();
                     }
                     if (vd->vd_ndx == versym_[index]) {
                         version = std::string(strtab_ + vda->vda_name);
@@ -205,9 +205,9 @@ std::pair<std::string, std::string> ELFBinary::GetVersion(int index) {
                 }
                 vd = (Elf_Verdef*)((char*)vd + vd->vd_next);
             }
-            if (soname != "" && version != "") {
-                LOG(INFO) << "Find Elf_Verdef corresponds to " << versym_[index] << SOLD_LOG_KEY(soname) << SOLD_LOG_KEY(version);
-                return std::make_pair(soname, version);
+            if (filename != "" && version != "") {
+                LOG(INFO) << "Find Elf_Verdef corresponds to " << versym_[index] << SOLD_LOG_KEY(filename) << SOLD_LOG_KEY(version);
+                return std::make_pair(filename, version);
             }
         }
 

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -95,6 +95,7 @@ private:
     Elf_Sym* symtab_{nullptr};
 
     std::vector<std::string> neededs_;
+    // This is the name specified in the DT_SONAME field.
     std::string soname_;
     std::string runpath_;
     std::string rpath_;
@@ -112,6 +113,7 @@ private:
     std::vector<uintptr_t> init_array_;
     std::vector<uintptr_t> fini_array_;
 
+    // This is the name on the filsysytem
     std::string name_;
     std::vector<Syminfo> syms_;
 

--- a/sold.cc
+++ b/sold.cc
@@ -278,7 +278,7 @@ private:
         for (const auto& p : libraries_) {
             ELFBinary* bin = p.second.get();
             if (!linked.count(bin)) {
-                neededs.insert(bin->soname());
+                neededs.insert(bin->name());
             }
         }
 


### PR DESCRIPTION
Some shared objects such as `libgomp-7c85b1e2.so.1` have a DT_SONAME field which is different from their name on the files system. So,  in Elf_Verdef and DT_NEEDED, we must use the name on the file system.
