### PR TITLE
Use only the first Elf_Verdaux entry

### DIFF
--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -201,15 +201,15 @@ std::pair<std::string, std::string> ELFBinary::GetVersion(int index, const std::
             std::string soname, version;
             for (int i = 0; i < verdefnum_; ++i) {
                 Elf_Verdaux* vda = (Elf_Verdaux*)((char*)vd + vd->vd_aux);
-                for (int j = 0; j < vd->vd_cnt; ++j) {
-                    if (vd->vd_flags & VER_FLG_BASE) {
-                        soname = std::string(strtab_ + vda->vda_name);
-                    }
-                    if (vd->vd_ndx == versym_[index]) {
-                        version = std::string(strtab_ + vda->vda_name);
-                    }
-                    vda = (Elf_Verdaux*)((char*)vda + vda->vda_next);
+
+                if (vd->vd_flags & VER_FLG_BASE) {
+                    soname = std::string(strtab_ + vda->vda_name);
                 }
+                if (vd->vd_ndx == versym_[index]) {
+                    version = std::string(strtab_ + vda->vda_name);
+                }
+                vda = (Elf_Verdaux*)((char*)vda + vda->vda_next);
+
                 vd = (Elf_Verdef*)((char*)vd + vd->vd_next);
             }
             if (soname != "" && version != "") {


### PR DESCRIPTION
We must use only the first Elf_Verdaux entry for each Elf_Verdex entries. (I am surprised that glibc never uses vda_next field.)

Reference
- glibc does not follow a chain of Elf_Verdaux.
https://github.com/bminor/glibc/blob/9538f6b95a3be228edc078ce58258f0574142e0c/elf/dl-version.c#L111