### PR TITLE
Use valid filename_to_soname in print_dynsymtab

### DIFF
--- a/print_dtrela.cc
+++ b/print_dtrela.cc
@@ -9,6 +9,8 @@
 #include <iostream>
 
 int main(int argc, const char* argv[]) {
+    google::InitGoogleLogging(argv[0]);
+
     if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program parse DT_RELA of the given ELF file." << std::endl;
         return 1;

--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -15,6 +15,8 @@
 #include "sold.h"
 
 int main(int argc, const char* argv[]) {
+    google::InitGoogleLogging(argv[0]);
+
     if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program parse DT_SYMTAB of the given ELF file." << std::endl;
         return 1;

--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -12,13 +12,18 @@
 
 #include <iostream>
 
+#include "sold.h"
+
 int main(int argc, const char* argv[]) {
     if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program parse DT_SYMTAB of the given ELF file." << std::endl;
         return 1;
     }
 
+    // This Sold class instrance is used only to get filename_to_soname map.
+    Sold sold(argv[1], {}, false);
+
     auto b = ReadELF(argv[1]);
-    b->ReadDynSymtab({});
+    b->ReadDynSymtab(sold.filename_to_soname());
     std::cout << b->ShowDynSymtab();
 }

--- a/print_tls.cc
+++ b/print_tls.cc
@@ -9,6 +9,8 @@
 #include <iostream>
 
 int main(int argc, const char* argv[]) {
+    google::InitGoogleLogging(argv[0]);
+
     if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program shows TLS entries of the given ELF file." << std::endl;
         return 1;

--- a/print_version.cc
+++ b/print_version.cc
@@ -9,6 +9,8 @@
 #include <iostream>
 
 int main(int argc, const char* argv[]) {
+    google::InitGoogleLogging(argv[0]);
+
     if (argc != 2) {
         std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program shows verneed information of the given ELF file." << std::endl;
         return 1;

--- a/sold.h
+++ b/sold.h
@@ -21,6 +21,8 @@ public:
 
     void Link(const std::string& out_filename);
 
+    const std::map<std::string, std::string> filename_to_soname() { return filename_to_soname_; };
+
 private:
     template <class T>
     void Write(FILE* fp, const T& v) {


### PR DESCRIPTION
`print_dynsymtab` caused runtime errors because we gave an empty map as the filename_to_soname argument. I fixed it in this PR.

Reference
- [96b36ca0 Stop running print_dynsymtab and print_tls because they cause SEGV relating to an empty filename_to_soname. I will fix this bug later.](https://github.com/shinh/sold/pull/37/commits/96b36ca00ea0a559bb5663c31f4b6b9504fa4191)