### PR TITLE
Search symbols using no version information in the fallback plan

### DIFF
--- a/symtab_builder.cc
+++ b/symtab_builder.cc
@@ -59,10 +59,7 @@ bool SymtabBuilder::Resolve(const std::string& name, const std::string& soname, 
         if (found == src_syms_.end() && soname.empty() && version.empty()) {
             // When we cannot find a symbol using (name, soname, version), we
             // try to find a symbol using only a name. In this case, you must
-            // not forget to check VERSYM_HIDDEN. Although there is no
-            // description of VERSYM_HIDDEN in glibc, you can find it in
-            // binutils source code.
-            // https://github.com/gittup/binutils/blob/8db2e9c8d085222ac7b57272ee263733ae193565/include/elf/common.h#L816
+            // not forget to check VERSYM_HIDDEN.
             LOG(INFO) << "Try to find " << name << " without version information.";
             found = std::find_if(src_syms_.begin(), src_syms_.end(),
                                  [&name](auto p) { return std::get<0>(p.first) == name && ((p.second.first & VERSYM_HIDDEN) == 0); });

--- a/symtab_builder.cc
+++ b/symtab_builder.cc
@@ -2,6 +2,7 @@
 #include "version_builder.h"
 
 #include <algorithm>
+#include <functional>
 #include <limits>
 
 SymtabBuilder::SymtabBuilder() {
@@ -20,11 +21,17 @@ SymtabBuilder::SymtabBuilder() {
 
 void SymtabBuilder::SetSrcSyms(std::vector<Syminfo> syms) {
     for (const auto& s : syms) {
-        auto p = src_syms_.find({s.name, s.soname, s.version});
+        auto found = src_syms_.find({s.name, s.soname, s.version});
         // TODO(akirakawata) Do we need this if? LoadDynSymtab should returns
-        // unique symbols therefore p == src_syms_.end() is true always.
-        if (p == src_syms_.end() || p->second.second == NULL || !IsDefined(*p->second.second)) {
+        // unique symbols therefore found == src_syms_.end() is true always.
+        if (found == src_syms_.end() || found->second.second == NULL || !IsDefined(*found->second.second)) {
             src_syms_[{s.name, s.soname, s.version}] = {s.versym, s.sym};
+        }
+
+        auto found_fallback = src_fallback_syms_.find(s.name);
+        if ((s.versym & VERSYM_HIDDEN) == 0 && (found_fallback == src_fallback_syms_.end() || found_fallback->second.second == NULL ||
+                                                !IsDefined(*found_fallback->second.second))) {
+            src_fallback_syms_[s.name] = {s.versym, s.sym};
         }
     }
 }
@@ -54,24 +61,31 @@ bool SymtabBuilder::Resolve(const std::string& name, const std::string& soname, 
     if (found != syms_.end()) {
         sym = found->second;
     } else {
-        auto found = src_syms_.find({name, soname, version});
+        Elf_Versym versym = 0;
+        Elf_Sym* symp = nullptr;
 
-        if (found == src_syms_.end() && soname.empty() && version.empty()) {
-            // When we cannot find a symbol using (name, soname, version), we
-            // try to find a symbol using only a name. In this case, you must
-            // not forget to check VERSYM_HIDDEN.
-            LOG(INFO) << "Try to find " << name << " without version information.";
-            found = std::find_if(src_syms_.begin(), src_syms_.end(),
-                                 [&name](auto p) { return std::get<0>(p.first) == name && ((p.second.first & VERSYM_HIDDEN) == 0); });
+        {
+            auto found = src_syms_.find({name, soname, version});
+            if (found != src_syms_.end()) {
+                versym = found->second.first;
+                symp = found->second.second;
+            } else {
+                auto found_fallback = src_fallback_syms_.find(name);
+                if (found_fallback != src_fallback_syms_.end()) {
+                    LOG(INFO) << "Use fallback version of " << name;
+                    versym = found_fallback->second.first;
+                    symp = found_fallback->second.second;
+                }
+            }
         }
 
-        if (found != src_syms_.end()) {
-            sym.sym = *found->second.second;
+        if (symp != nullptr) {
+            sym.sym = *symp;
             if (IsDefined(sym.sym)) {
                 LOG(INFO) << "Symbol (" << name << ", " << soname << ", " << version << ") found";
             } else {
                 LOG(INFO) << "Symbol (undef/weak) (" << name << ", " << soname << ", " << version << ") found";
-                Syminfo s{name, soname, version, found->second.first, NULL};
+                Syminfo s{name, soname, version, versym, NULL};
                 sym.index = AddSym(s);
                 CHECK(syms_.emplace(std::make_tuple(name, soname, version), sym).second);
             }
@@ -107,12 +121,28 @@ uintptr_t SymtabBuilder::ResolveCopy(const std::string& name, const std::string&
     if (found != syms_.end()) {
         sym = found->second;
     } else {
-        auto found = src_syms_.find({name, soname, version});
+        Elf_Versym versym = 0;
+        Elf_Sym* symp = nullptr;
 
-        if (found != src_syms_.end()) {
+        {
+            auto found = src_syms_.find({name, soname, version});
+            if (found != src_syms_.end()) {
+                versym = found->second.first;
+                symp = found->second.second;
+            } else {
+                auto found_fallback = src_fallback_syms_.find(name);
+                if (found_fallback != src_fallback_syms_.end()) {
+                    LOG(INFO) << "Use fallback version of " << name;
+                    versym = found_fallback->second.first;
+                    symp = found_fallback->second.second;
+                }
+            }
+        }
+
+        if (symp != nullptr) {
             LOG(INFO) << "Symbol " << name << " found for copy";
-            sym.sym = *found->second.second;
-            Syminfo s{name, soname, version, found->second.first, NULL};
+            sym.sym = *symp;
+            Syminfo s{name, soname, version, versym, NULL};
             sym.index = AddSym(s);
             CHECK(syms_.emplace(std::make_tuple(name, soname, version), sym).second);
         } else {

--- a/symtab_builder.h
+++ b/symtab_builder.h
@@ -41,8 +41,11 @@ private:
         uintptr_t index;
     };
 
-    // map from (name, soname, version) to Versym and Sym
+    // map from (name, soname, version) to (Versym, Sym*)
     std::map<std::tuple<std::string, std::string, std::string>, std::pair<Elf_Versym, Elf_Sym*> > src_syms_;
+    // map from name to (Versym, Sym*)
+    // We use src_fallback_syms_ when we don't have version information.
+    std::map<std::string, std::pair<Elf_Versym, Elf_Sym*> > src_fallback_syms_;
     std::map<std::tuple<std::string, std::string, std::string>, Symbol> syms_;
 
     std::vector<Syminfo> exposed_syms_;

--- a/utils.h
+++ b/utils.h
@@ -37,7 +37,9 @@
 #define ELF_R_TYPE(val) ELF64_R_TYPE(val)
 #define ELF_R_INFO(sym, type) ELF64_R_INFO(sym, type)
 
-// From binutils
+// Although there is no description of VERSYM_HIDDEN in glibc, you can find it
+// in binutils source code.
+// https://github.com/gittup/binutils/blob/8db2e9c8d085222ac7b57272ee263733ae193565/include/elf/common.h#L816
 #define VERSYM_HIDDEN 0x8000
 #define VERSYM_VERSION 0x7fff
 

--- a/utils.h
+++ b/utils.h
@@ -37,6 +37,10 @@
 #define ELF_R_TYPE(val) ELF64_R_TYPE(val)
 #define ELF_R_INFO(sym, type) ELF64_R_INFO(sym, type)
 
+// From binutils
+#define VERSYM_HIDDEN 0x8000
+#define VERSYM_VERSION 0x7fff
+
 static const Elf_Versym NO_VERSION_INFO = 0xffff;
 
 std::vector<std::string> SplitString(const std::string& str, const std::string& sep);


### PR DESCRIPTION
When we have no version information for the needed symbol, we must search it without version information.

In this case, we must check whether the VERSYM_HIDDEN(0x8000) bit of versym is set, as you said in https://github.com/shinh/sold/pull/46#discussion_r524304232.