### PR TITLE
Suppress emitting unnecessary verneed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,23 +17,5 @@ jobs:
       run: cmake --build build
     - name: Test
       run: cd build && ctest --output-on-failure
-    - name: hello-gcc
-      run: cd tests/hello-gcc && ./test.sh
-    - name: hello-g++
-      run: cd tests/hello-g++ && ./test.sh
-    - name: just-return-gcc 
-      run: cd tests/just-return-gcc && ./test.sh
-    - name: just-return-g++
-      run: cd tests/just-return-g++ && ./test.sh
-    - name: simple-lib-gcc
-      run: cd tests/simple-lib-gcc && ./test.sh
-    - name: simple-lib-g++
-      run: cd tests/simple-lib-g++ && ./test.sh
-    - name: version-gcc
-      run: cd tests/version-gcc && ./test.sh
-    - name: tls-lib-gcc
-      run: cd tests/tls-lib-gcc && ./test.sh
-    - name: tls-lib-gcc-without-base
-      run: cd tests/tls-lib-gcc-without-base && ./test.sh
-    - name: tls-multiple-lib-gcc
-      run: cd tests/tls-multiple-lib-gcc && ./test.sh
+    - name: run-all-tests
+      run: cd tests && ./run-all-tests.sh

--- a/sold.cc
+++ b/sold.cc
@@ -48,8 +48,10 @@ void Sold::Link(const std::string& out_filename) {
 
     shdr_.RegisterShdr(GnuHashOffset(), GnuHashSize(), ShdrBuilder::ShdrType::GnuHash);
     shdr_.RegisterShdr(SymtabOffset(), SymtabSize(), ShdrBuilder::ShdrType::Dynsym, sizeof(Elf_Sym));
-    shdr_.RegisterShdr(VersymOffset(), VersymSize(), ShdrBuilder::ShdrType::GnuVersion, sizeof(Elf_Versym));
-    shdr_.RegisterShdr(VerneedOffset(), VerneedSize(), ShdrBuilder::ShdrType::GnuVersionR, 0, version_.NumVerneed());
+    if (version_.NumVerneed() > 0) {
+        shdr_.RegisterShdr(VersymOffset(), VersymSize(), ShdrBuilder::ShdrType::GnuVersion, sizeof(Elf_Versym));
+        shdr_.RegisterShdr(VerneedOffset(), VerneedSize(), ShdrBuilder::ShdrType::GnuVersionR, 0, version_.NumVerneed());
+    }
     shdr_.RegisterShdr(RelOffset(), RelSize(), ShdrBuilder::ShdrType::RelaDyn, sizeof(Elf_Rel));
     shdr_.RegisterShdr(InitArrayOffset(), InitArraySize(), ShdrBuilder::ShdrType::InitArray);
     shdr_.RegisterShdr(FiniArrayOffset(), FiniArraySize(), ShdrBuilder::ShdrType::FiniArray);
@@ -190,9 +192,11 @@ void Sold::BuildDynamic() {
     MakeDyn(DT_SYMTAB, SymtabOffset());
     MakeDyn(DT_SYMENT, sizeof(Elf_Sym));
 
-    MakeDyn(DT_VERSYM, VersymOffset());
-    MakeDyn(DT_VERNEEDNUM, version_.NumVerneed());
-    MakeDyn(DT_VERNEED, VerneedOffset());
+    if (version_.NumVerneed() > 0) {
+        MakeDyn(DT_VERSYM, VersymOffset());
+        MakeDyn(DT_VERNEEDNUM, version_.NumVerneed());
+        MakeDyn(DT_VERNEED, VerneedOffset());
+    }
 
     MakeDyn(DT_RELA, RelOffset());
     MakeDyn(DT_RELAENT, sizeof(Elf_Rel));

--- a/tests/call_once-g++/test.sh
+++ b/tests/call_once-g++/test.sh
@@ -13,4 +13,4 @@ ln -sf lib.so.soldout lib.so
 # Use original
 # ln -sf lib.so.original lib.so
 
-./main
+LD_LIBRARY_PATH=. ./main

--- a/tests/inheritance-g++/test.sh
+++ b/tests/inheritance-g++/test.sh
@@ -13,4 +13,4 @@ ln -sf lib.so.soldout lib.so
 # Use original
 # ln -sf lib.so.original lib.so
 
-./main
+LD_LIBRARY_PATH=. ./main

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -1,6 +1,6 @@
 #! /bin/bash -eu
 
-for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc
+for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++
 do
     pushd `pwd`
     cd $dir

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -1,6 +1,6 @@
 #! /bin/bash -eu
 
-for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++
+for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++
 do
     pushd `pwd`
     cd $dir

--- a/tests/static-in-class-g++/lib.cc
+++ b/tests/static-in-class-g++/lib.cc
@@ -1,0 +1,9 @@
+#include "lib.h"
+
+int X::i_static = 42;
+double X::d_static = 42.00;
+
+double func() {
+    X x;
+    return x.f();
+}

--- a/tests/static-in-class-g++/lib.h
+++ b/tests/static-in-class-g++/lib.h
@@ -1,0 +1,10 @@
+class X {
+public:
+    double f() { return i_static + d_static; }
+
+private:
+    static int i_static;
+    static double d_static;
+};
+
+double func();

--- a/tests/static-in-class-g++/main.cc
+++ b/tests/static-in-class-g++/main.cc
@@ -1,0 +1,7 @@
+#include "lib.h"
+
+#include <iostream>
+
+int main() {
+    std::cout << func() << std::endl;
+}

--- a/tests/static-in-class-g++/test.sh
+++ b/tests/static-in-class-g++/test.sh
@@ -1,7 +1,8 @@
 #! /bin/bash -eu
 
 g++ -fPIC -c -o lib.o lib.cc
-g++ -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
+g++ -fPIC -S -o lib.asm lib.cc
+g++ -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so
 
 mv lib.so lib.so.original
@@ -9,10 +10,8 @@ mv lib.so lib.so.original
 
 # Use sold
 ln -sf lib.so.soldout lib.so
-echo ----------- Use sold -----------
-LD_LIBRARY_PATH=. ./main
 
 # Use original
-ln -sf lib.so.original lib.so
-echo ----------- Use original -----------
+# ln -sf lib.so.original lib.so
+
 LD_LIBRARY_PATH=. ./main

--- a/tests/static-in-function-g++/test.sh
+++ b/tests/static-in-function-g++/test.sh
@@ -14,4 +14,4 @@ ln -sf lib.so.soldout lib.so
 # Use original
 # ln -sf lib.so.original lib.so
 
-./main
+LD_LIBRARY_PATH=. ./main

--- a/tests/tls-bss-g++/test.sh
+++ b/tests/tls-bss-g++/test.sh
@@ -1,6 +1,5 @@
 #! /bin/bash -eu
 
-g++ -Wl,--hash-style=gnu -o main main.cc
-
+g++ -o main main.cc
 ../../build/sold main -o main.out --section-headers
 ./main.out

--- a/tests/tls-dlopen-gcc/test.sh
+++ b/tests/tls-dlopen-gcc/test.sh
@@ -13,4 +13,4 @@ ln -sf lib.so.soldout lib.so
 # Use original
 # ln -sf lib.so.original lib.so
 
-./main
+LD_LIBRARY_PATH=. ./main

--- a/tests/tls-thread-g++/test.sh
+++ b/tests/tls-thread-g++/test.sh
@@ -13,4 +13,4 @@ ln -sf lib.so.soldout lib.so
 # Use original
 # ln -sf lib.so.original lib.so
 
-./main
+LD_LIBRARY_PATH=. ./main

--- a/tests/typeid-g++/test.sh
+++ b/tests/typeid-g++/test.sh
@@ -10,9 +10,9 @@ mv lib.so lib.so.original
 # Use sold
 ln -sf lib.so.soldout lib.so
 echo ----------- Use sold -----------
-./main
+LD_LIBRARY_PATH=. ./main
 
 # Use original
 ln -sf lib.so.original lib.so
 echo ----------- Use original -----------
-./main
+LD_LIBRARY_PATH=. ./main

--- a/ubuntu20.04.Dockerfile
+++ b/ubuntu20.04.Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
 RUN apt-get install -y ninja-build cmake gcc g++ git
 COPY . /sold

--- a/version_builder.cc
+++ b/version_builder.cc
@@ -54,8 +54,10 @@ uintptr_t VersionBuilder::SizeVerneed() const {
 }
 
 void VersionBuilder::EmitVersym(FILE* fp) {
-    for (auto v : vers) {
-        CHECK(fwrite(&v, sizeof(v), 1, fp) == 1);
+    if (data.size() > 0) {
+        for (auto v : vers) {
+            CHECK(fwrite(&v, sizeof(v), 1, fp) == 1);
+        }
     }
 }
 

--- a/version_builder.h
+++ b/version_builder.h
@@ -12,7 +12,7 @@ class VersionBuilder {
 public:
     void Add(Elf_Versym versym, const std::string& soname, const std::string& version, StrtabBuilder& strtab, const unsigned char st_info);
 
-    uintptr_t SizeVersym() const { return vers.size() * sizeof(Elf_Versym); }
+    uintptr_t SizeVersym() const { return (data.size() > 0) ? vers.size() * sizeof(Elf_Versym) : 0; }
 
     uintptr_t SizeVerneed() const;
 


### PR DESCRIPTION
When there is no Verneed entry, we should not make DT_VERNEED entry. This is because ld-linux.so check vn_version even if DT_VERNEEDNUM is 0. When there is no Verneed entry, I stopped to emit Versyms also. Because emitting Versyms causes a crash in relocation. I don't know the reason.

Although I said there is a bug in the handling of static variables at #51 (comment), it is not true. The crash in tests/static-in-function-g++ was caused by this bug.

Reference
- https://github.com/bminor/glibc/blob/088e9625378f25607acff3daf7a79cbdee497043/elf/dl-version.c#L185