### PR TITLE
Cannot handle access to TLS variable without R_X86_64_DTPOFF64

### DIFF
--- a/tests/tls-multiple-module-g++/.gitignore
+++ b/tests/tls-multiple-module-g++/.gitignore
@@ -1,0 +1,5 @@
+libfugahoge.so.original
+libfugahoge.so.soldout
+libfuga.so
+libhoge.so
+main

--- a/tests/tls-multiple-module-g++/fuga.cc
+++ b/tests/tls-multiple-module-g++/fuga.cc
@@ -1,0 +1,14 @@
+#include "fuga.h"
+
+namespace {
+thread_local uint64_t fuga_data = 0xDEADBEEF;
+thread_local uint64_t fuga_bss;
+}  // namespace
+
+uint64_t get_fuga_data() {
+    return fuga_data;
+}
+
+uint64_t get_fuga_bss() {
+    return fuga_bss;
+}

--- a/tests/tls-multiple-module-g++/fuga.h
+++ b/tests/tls-multiple-module-g++/fuga.h
@@ -1,0 +1,5 @@
+#include <cstdint>
+
+void show_fuga();
+uint64_t get_fuga_data();
+uint64_t get_fuga_bss();

--- a/tests/tls-multiple-module-g++/fugahoge.cc
+++ b/tests/tls-multiple-module-g++/fugahoge.cc
@@ -1,0 +1,18 @@
+#include <cassert>
+
+#include <iostream>
+
+#include "fuga.h"
+#include "hoge.h"
+
+extern "C" void show_fuga_hoge() {
+    uint64_t fuga_data = get_fuga_data();
+    uint64_t fuga_bss = get_fuga_bss();
+    uint64_t hoge_data = get_hoge_data();
+    uint64_t hoge_bss = get_hoge_bss();
+
+    std::cout << std::hex << "fuga_data = " << fuga_data << ", fuga_bss = " << fuga_bss << std::endl
+              << "hoge_data = " << hoge_data << ", hoge_bss = " << hoge_bss << std::endl;
+
+    assert(fuga_data == 0xDEADBEEF && fuga_bss == 0 && hoge_data == 0xABCDEFAB && hoge_bss == 0);
+}

--- a/tests/tls-multiple-module-g++/hoge.cc
+++ b/tests/tls-multiple-module-g++/hoge.cc
@@ -1,0 +1,14 @@
+#include "hoge.h"
+
+namespace {
+thread_local uint64_t hoge_data = 0xABCDEFAB;
+thread_local uint64_t hoge_bss;
+}  // namespace
+
+uint64_t get_hoge_data() {
+    return hoge_data;
+}
+
+uint64_t get_hoge_bss() {
+    return hoge_bss;
+}

--- a/tests/tls-multiple-module-g++/hoge.h
+++ b/tests/tls-multiple-module-g++/hoge.h
@@ -1,0 +1,5 @@
+#include <cstdint>
+
+void show_hoge();
+uint64_t get_hoge_data();
+uint64_t get_hoge_bss();

--- a/tests/tls-multiple-module-g++/main.cc
+++ b/tests/tls-multiple-module-g++/main.cc
@@ -1,0 +1,32 @@
+#include <dlfcn.h>
+
+#include <iostream>
+
+int main() {
+    std::cout << "=========== libfugahoge.so.original ==========" << std::endl;
+    void* handle = dlopen("./libfugahoge.so.original", RTLD_LAZY);
+    if (handle == NULL) {
+        std::cout << "Cannot find libfugahoge.so.original" << std::endl;
+        return 0;
+    }
+    int (*show_fuga_hoge)() = (int (*)())dlsym(handle, "show_fuga_hoge");
+    if (show_fuga_hoge == NULL) {
+        std::cout << "Cannot find show_fuga_hoge" << std::endl;
+        return 0;
+    }
+    show_fuga_hoge();
+
+    std::cout << "=========== libfugahoge.so.soldout ==========" << std::endl;
+    handle = dlopen("./libfugahoge.so.soldout", RTLD_LAZY);
+    if (handle == NULL) {
+        std::cout << "Cannot find libfugahoge.so.soldout" << std::endl;
+        return 0;
+    }
+    show_fuga_hoge = (int (*)())dlsym(handle, "show_fuga_hoge");
+    if (show_fuga_hoge == NULL) {
+        std::cout << "Cannot find show_fuga_hoge" << std::endl;
+        return 0;
+    }
+    show_fuga_hoge();
+    return 0;
+}

--- a/tests/tls-multiple-module-g++/test.sh
+++ b/tests/tls-multiple-module-g++/test.sh
@@ -1,0 +1,10 @@
+#! /bin/bash -eu
+
+g++ -shared -fPIC -o libfuga.so -Wl,-soname,libfuga.so fuga.cc
+g++ -shared -fPIC -o libhoge.so -Wl,-soname,libhoge.so hoge.cc
+g++ -shared -fPIC -o libfugahoge.so.original fugahoge.cc libfuga.so libhoge.so
+g++ -o main main.cc -ldl 
+
+LD_LIBRARY_PATH=. ../../build/sold -i libfugahoge.so.original -o libfugahoge.so.soldout --section-headers
+
+LD_LIBRARY_PATH=. ./main


### PR DESCRIPTION
sold cannot pass this test case now. This is because sold doesn't care about the offsets of TLS variables when there are no R_X86_64_DTPOFF64 relocations.

In this test case, libfuga.so and libhoge.so have their own TLS variables in the anonymous namespace. Therefore, these libraries access their TLS variables only with R_X86_64_DTPMOD64.