### PR TITLE
Fix TLS variables of Local Dynamic model

### DIFF
--- a/elf_binary.h
+++ b/elf_binary.h
@@ -35,6 +35,7 @@ public:
     size_t num_plt_rels() const { return num_plt_rels_; }
 
     const char* head() const { return head_; }
+    size_t size() const { return size_; }
 
     const std::string& name() const { return name_; }
 
@@ -48,6 +49,8 @@ public:
     Range GetRange() const;
 
     bool InTLS(uintptr_t offset) const;
+    bool InTLSData(uintptr_t offset) const;
+    bool InTLSBSS(uintptr_t offset) const;
 
     void ReadDynSymtab(const std::map<std::string, std::string>& filename_to_soname);
 
@@ -73,14 +76,15 @@ public:
 
     std::pair<std::string, std::string> GetVersion(int index, const std::map<std::string, std::string>& filename_to_soname);
 
+    Elf_Addr OffsetFromAddr(Elf_Addr addr);
+    Elf_Addr AddrFromOffset(Elf_Addr offset);
+
 private:
     void ParsePhdrs();
 
     void ParseDynamic(size_t off, size_t size);
 
     void ParseFuncArray(uintptr_t* array, uintptr_t size, std::vector<uintptr_t>* out);
-
-    Elf_Addr OffsetFromAddr(Elf_Addr addr);
 
     const std::string filename_;
     int fd_;

--- a/relocation-list-up.sh
+++ b/relocation-list-up.sh
@@ -1,0 +1,21 @@
+#! /bin/bash
+# List up all relocation entries for the given shared object.
+# When you give the second argument, this script filter the output with it.
+# ./relocation-check.sh SHARED_OBJECT [RELOCATION_ENTRY]
+
+depends=$(ldd $1 | awk 'NR>1' | awk '{print $3}')
+
+for d in $1 ${depends}
+do
+    if [ -z $2 ]
+    then
+        relos=$(readelf -r ${d})
+    else
+        relos=$(readelf -r ${d} | grep $2)
+    fi
+    IFS=$'\n'
+    for r in ${relos}
+    do
+        echo ${d} ${r}
+    done
+done

--- a/search-symbol.sh
+++ b/search-symbol.sh
@@ -1,0 +1,23 @@
+#! /bin/bash
+# This shellscript find all shared object which contains the specified
+# symbol.
+
+if [ -z $1 ]
+then
+    echo You must specify the name of the symbol.
+    exit 1
+fi
+
+sym=$1
+sos=`ldconfig -p | awk -F '=>' '{print $2}' | grep so | sort | uniq`
+
+for s in ${sos}
+do
+    PRE_IFS=$IFS
+    IFS=$'\n'
+    for l in `readelf -s $s | grep -e ${sym} | grep -v UND`
+    do
+        echo ${l} in ${s}
+    done
+    IFS=$PRE_IFS
+done

--- a/sold.cc
+++ b/sold.cc
@@ -496,9 +496,90 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
             break;
         }
 
-        // TODO(akawashiro) Fill here with some exaplanation.
-        case R_X86_64_DTPMOD64:
-        case R_X86_64_DTPOFF64:
+        // TODO(akawashiro) Handle TLS variables in executables.
+        case R_X86_64_DTPMOD64: {
+            const std::string name = bin->Str(sym->st_name);
+            uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+            newrel.r_info = ELF_R_INFO(index, type);
+
+            if (bin->tls() == NULL) {
+                LOG(INFO) << SOLD_LOG_64BITS(bin->tls()) << " is null. This relocation is TLS generic dynamic model.";
+                break;
+            }
+
+            uint64_t* mod_on_got =
+                const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(bin->head() + bin->OffsetFromAddr(rel->r_offset)));
+            uint64_t* offset_on_got = mod_on_got + 1;
+            const bool is_bss = bin->InTLSBSS(*offset_on_got);
+
+            // We assume dl_tls_index exists in GOT. This struct is used as
+            // the argument of __tls_get_addr.
+            //
+            // typedef struct dl_tls_index
+            // {
+            //   uint64_t ti_module; <--- mod_on_got
+            //   uint64_t ti_offset; <--- offset_on_got
+            // } tls_index;
+            //
+            // In TLS generic dynamic model, both of ti_module and
+            // ti_offset are rewrite by R_X86_64_DTPMOD64 and
+            // R_X86_64_DTPOFF64, respectively.
+            //
+            // In TLS local dynamic model, only ti_module is
+            // rewrite by R_X86_64_DTPMOD64 and offset_on_got is fixed
+            // in the link process. Therefore, we must rewrite the fixed
+            // offset because we remap the TLS template image.
+
+            std::vector<int> rewrite_rel_types;  // Type of relocations which rewrite ti_module.
+            for (size_t i = 0; i < bin->num_rels(); ++i) {
+                if (rel->r_offset + sizeof(uint64_t) <= bin->rel()[i].r_offset &&
+                    bin->rel()[i].r_offset < rel->r_offset + sizeof(uint64_t) + sizeof(uint64_t)) {
+                    rewrite_rel_types.emplace_back(ELF_R_TYPE(bin->rel()[i].r_info));
+                }
+            }
+
+            CHECK(rewrite_rel_types.size() == 0 || (rewrite_rel_types.size() == 1 && rewrite_rel_types[0] == R_X86_64_DTPOFF64))
+                << SOLD_LOG_KEY(rewrite_rel_types.size()) << SOLD_LOG_KEY(ShowRelocationType(rewrite_rel_types[0]));
+
+            if (rewrite_rel_types.size() == 1) {
+                LOG(INFO) << "R_X86_64_DTPOFF64 exists next to R_X86_64_DTPMOD64. This relocation is TLS generic dynamic model.";
+                break;
+            }
+
+            LOG(INFO) << "R_X86_64_DTPMOD64 relocation in TLS local dynamic model. " << SOLD_LOG_KEY(*rel) << SOLD_LOG_KEY(newrel)
+                      << SOLD_LOG_64BITS(bin->OffsetFromAddr(rel->r_offset)) << SOLD_LOG_64BITS(*mod_on_got)
+                      << SOLD_LOG_64BITS(*offset_on_got) << SOLD_LOG_64BITS(bin->tls()->p_filesz) << SOLD_LOG_KEY(is_bss)
+                      << SOLD_LOG_64BITS(tls_.data[tls_.bin_to_index[bin]].file_offset)
+                      << SOLD_LOG_64BITS(tls_.data[tls_.bin_to_index[bin]].bss_offset);
+
+            CHECK(ELF_R_SYM(rel->r_info) == 0)
+                << "The symbol associated with R_X86_64_DTPMOD64 in TLS local dynamic model should be the dummy.";
+
+            if (is_bss) {
+                // .tbss is remapped from
+                // [bin->tls()->p_filesz, bin->tls()->p_memsz) to
+                // [tls_.data[tls_.bin_to_index[bin]].bss_offset,
+                //  tls_.data[tls_.bin_to_index[bin]].bss_offset + bin->tls()->p_memsz - bin->tls()->p_filesz)
+                *offset_on_got += tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz;
+            } else {
+                // .tdata is remapped from
+                // [0, bin->tls()->p_filesz) to
+                // [tls_.data[tls_.bin_to_index[bin]].file_offset,
+                //  tls_.data[tls_.bin_to_index[bin]].file_offset + bin->tls()->p_filesz)
+                *offset_on_got += tls_.data[tls_.bin_to_index[bin]].file_offset;
+            }
+            break;
+        }
+
+        case R_X86_64_DTPOFF64: {
+            const std::string name = bin->Str(sym->st_name);
+            uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+            newrel.r_info = ELF_R_INFO(index, type);
+            LOG(INFO) << "R_X86_64_DTPOFF64 relocation: " << SOLD_LOG_KEY(*rel) << SOLD_LOG_KEY(newrel)
+                      << SOLD_LOG_64BITS(bin->OffsetFromAddr(rel->r_offset));
+            break;
+        }
+
         case R_X86_64_COPY: {
             const std::string name = bin->Str(sym->st_name);
             uintptr_t index = syms_.ResolveCopy(name, soname, version_name);

--- a/sold.cc
+++ b/sold.cc
@@ -498,6 +498,7 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
 
         // TODO(akawashiro) Handle TLS variables in executables.
         case R_X86_64_DTPMOD64: {
+            // TODO(akawashiro) Refactor out for Arch64
             const std::string name = bin->Str(sym->st_name);
             uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
             newrel.r_info = ELF_R_INFO(index, type);

--- a/sold.cc
+++ b/sold.cc
@@ -521,14 +521,14 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
             //   uint64_t ti_offset; <--- offset_on_got
             // } tls_index;
             //
-            // In TLS generic dynamic model, both of ti_module and
-            // ti_offset are rewrite by R_X86_64_DTPMOD64 and
-            // R_X86_64_DTPOFF64, respectively.
+            // In TLS generic dynamic model, both ti_module and ti_offset are
+            // rewritten by R_X86_64_DTPMOD64 and R_X86_64_DTPOFF64,
+            // respectively.
             //
-            // In TLS local dynamic model, only ti_module is
-            // rewrite by R_X86_64_DTPMOD64 and offset_on_got is fixed
-            // in the link process. Therefore, we must rewrite the fixed
-            // offset because we remap the TLS template image.
+            // In TLS local dynamic model, the only ti_module is rewrite by
+            // R_X86_64_DTPMOD64 and ti_offset is fixed in the link process. We
+            // must rewrite the fixed ti_offset because we remap the TLS
+            // template.
 
             std::vector<int> rewrite_rel_types;  // Type of relocations which rewrite ti_module.
             for (size_t i = 0; i < bin->num_rels(); ++i) {
@@ -556,13 +556,13 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
                 << "The symbol associated with R_X86_64_DTPMOD64 in TLS local dynamic model should be the dummy.";
 
             if (is_bss) {
-                // .tbss is remapped from
+                // TLS variables without initial values are remapped from
                 // [bin->tls()->p_filesz, bin->tls()->p_memsz) to
                 // [tls_.data[tls_.bin_to_index[bin]].bss_offset,
                 //  tls_.data[tls_.bin_to_index[bin]].bss_offset + bin->tls()->p_memsz - bin->tls()->p_filesz)
                 *offset_on_got += tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz;
             } else {
-                // .tdata is remapped from
+                // TLS variables with initial values are remapped from
                 // [0, bin->tls()->p_filesz) to
                 // [tls_.data[tls_.bin_to_index[bin]].file_offset,
                 //  tls_.data[tls_.bin_to_index[bin]].file_offset + bin->tls()->p_filesz)

--- a/sold.h
+++ b/sold.h
@@ -205,6 +205,7 @@ private:
         }
     }
 
+    // Emit TLS initialization image
     void EmitTLS(FILE* fp) {
         EmitPad(fp, tls_file_offset_);
         CHECK(ftell(fp) == TLSOffset());

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -1,6 +1,6 @@
 #! /bin/bash -eu
 
-for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++
+for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++
 do
     pushd `pwd`
     cd $dir

--- a/tests/tls-multiple-module-g++/fuga.cc
+++ b/tests/tls-multiple-module-g++/fuga.cc
@@ -1,7 +1,7 @@
 #include "fuga.h"
 
 namespace {
-thread_local uint64_t fuga_data = 0xDEADBEEF;
+thread_local uint64_t fuga_data = 0xDEADBEEFDEADBEEF;
 thread_local uint64_t fuga_bss;
 }  // namespace
 

--- a/tests/tls-multiple-module-g++/fugahoge.cc
+++ b/tests/tls-multiple-module-g++/fugahoge.cc
@@ -14,5 +14,5 @@ extern "C" void show_fuga_hoge() {
     std::cout << std::hex << "fuga_data = " << fuga_data << ", fuga_bss = " << fuga_bss << std::endl
               << "hoge_data = " << hoge_data << ", hoge_bss = " << hoge_bss << std::endl;
 
-    assert(fuga_data == 0xDEADBEEF && fuga_bss == 0 && hoge_data == 0xABCDEFAB && hoge_bss == 0);
+    assert(fuga_data == 0xDEADBEEFDEADBEEF && fuga_bss == 0 && hoge_data == 0xABCDEFABCDEFABCD && hoge_bss == 0);
 }

--- a/tests/tls-multiple-module-g++/hoge.cc
+++ b/tests/tls-multiple-module-g++/hoge.cc
@@ -1,7 +1,7 @@
 #include "hoge.h"
 
 namespace {
-thread_local uint64_t hoge_data = 0xABCDEFAB;
+thread_local uint64_t hoge_data = 0xABCDEFABCDEFABCD;
 thread_local uint64_t hoge_bss;
 }  // namespace
 

--- a/tests/tls-multiple-module-g++/main.cc
+++ b/tests/tls-multiple-module-g++/main.cc
@@ -3,7 +3,7 @@
 #include <iostream>
 
 int main() {
-    std::cout << "=========== libfugahoge.so.original ==========" << std::endl;
+    std::cout << "---------- libfugahoge.so.original ----------" << std::endl;
     void* handle = dlopen("./libfugahoge.so.original", RTLD_LAZY);
     if (handle == NULL) {
         std::cout << "Cannot find libfugahoge.so.original" << std::endl;
@@ -16,7 +16,7 @@ int main() {
     }
     show_fuga_hoge();
 
-    std::cout << "=========== libfugahoge.so.soldout ==========" << std::endl;
+    std::cout << "---------- libfugahoge.so.soldout ----------" << std::endl;
     handle = dlopen("./libfugahoge.so.soldout", RTLD_LAZY);
     if (handle == NULL) {
         std::cout << "Cannot find libfugahoge.so.soldout" << std::endl;

--- a/utils.cc
+++ b/utils.cc
@@ -39,6 +39,103 @@ std::ostream& operator<<(std::ostream& os, const Syminfo& s) {
     return os;
 }
 
+std::string ShowRelocationType(int type) {
+    switch (type) {
+        case R_X86_64_NONE:
+            return "R_X86_64_NONE";
+        case R_X86_64_64:
+            return "R_X86_64_64";
+        case R_X86_64_PC32:
+            return "R_X86_64_PC32";
+        case R_X86_64_GOT32:
+            return "R_X86_64_GOT32";
+        case R_X86_64_PLT32:
+            return "R_X86_64_PLT32";
+        case R_X86_64_COPY:
+            return "R_X86_64_COPY";
+        case R_X86_64_GLOB_DAT:
+            return "R_X86_64_GLOB_DAT";
+        case R_X86_64_JUMP_SLOT:
+            return "R_X86_64_JUMP_SLOT";
+        case R_X86_64_RELATIVE:
+            return "R_X86_64_RELATIVE";
+        case R_X86_64_GOTPCREL:
+            return "R_X86_64_GOTPCREL";
+        case R_X86_64_32:
+            return "R_X86_64_32";
+        case R_X86_64_32S:
+            return "R_X86_64_32S";
+        case R_X86_64_16:
+            return "R_X86_64_16";
+        case R_X86_64_PC16:
+            return "R_X86_64_PC16";
+        case R_X86_64_8:
+            return "R_X86_64_8";
+        case R_X86_64_PC8:
+            return "R_X86_64_PC8";
+        case R_X86_64_DTPMOD64:
+            return "R_X86_64_DTPMOD64";
+        case R_X86_64_DTPOFF64:
+            return "R_X86_64_DTPOFF64";
+        case R_X86_64_TPOFF64:
+            return "R_X86_64_TPOFF64";
+        case R_X86_64_TLSGD:
+            return "R_X86_64_TLSGD";
+        case R_X86_64_TLSLD:
+            return "R_X86_64_TLSLD";
+        case R_X86_64_DTPOFF32:
+            return "R_X86_64_DTPOFF32";
+        case R_X86_64_GOTTPOFF:
+            return "R_X86_64_GOTTPOFF";
+        case R_X86_64_TPOFF32:
+            return "R_X86_64_TPOFF32";
+        case R_X86_64_PC64:
+            return "R_X86_64_PC64";
+        case R_X86_64_GOTOFF64:
+            return "R_X86_64_GOTOFF64";
+        case R_X86_64_GOTPC32:
+            return "R_X86_64_GOTPC32";
+        case R_X86_64_GOT64:
+            return "R_X86_64_GOT64";
+        case R_X86_64_GOTPCREL64:
+            return "R_X86_64_GOTPCREL64";
+        case R_X86_64_GOTPC64:
+            return "R_X86_64_GOTPC64";
+        case R_X86_64_GOTPLT64:
+            return "R_X86_64_GOTPLT64";
+        case R_X86_64_PLTOFF64:
+            return "R_X86_64_PLTOFF64";
+        case R_X86_64_SIZE32:
+            return "R_X86_64_SIZE32";
+        case R_X86_64_SIZE64:
+            return "R_X86_64_SIZE64";
+        case R_X86_64_GOTPC32_TLSDESC:
+            return "R_X86_64_GOTPC32_TLSDESC";
+        case R_X86_64_TLSDESC:
+            return "R_X86_64_TLSDESC";
+        case R_X86_64_IRELATIVE:
+            return "R_X86_64_IRELATIVE";
+        case R_X86_64_RELATIVE64:
+            return "R_X86_64_RELATIVE64";
+        case R_X86_64_GOTPCRELX:
+            return "R_X86_64_GOTPCRELX";
+        case R_X86_64_REX_GOTPCRELX:
+            return "R_X86_64_REX_GOTPCRELX";
+        case R_X86_64_NUM:
+            return "R_X86_64_NUM";
+        default: {
+            return HexString(type, 4);
+        }
+    }
+}
+
+std::ostream& operator<<(std::ostream& os, const Elf_Rel& r) {
+    os << "Elf_Rela{r_offset=" << SOLD_LOG_32BITS(r.r_offset) << ", r_info=" << SOLD_LOG_32BITS(r.r_info)
+       << ", ELF_R_SYM(r.r_info)=" << SOLD_LOG_16BITS(ELF_R_SYM(r.r_info))
+       << ", ELF_R_TYPE(r.r_info)=" << ShowRelocationType(ELF_R_TYPE(r.r_info)) << ", r_addend=" << SOLD_LOG_32BITS(r.r_addend) << "}";
+    return os;
+}
+
 bool is_special_ver_ndx(Elf64_Versym versym) {
     return (versym == VER_NDX_LOCAL || versym == VER_NDX_GLOBAL);
 }

--- a/utils.h
+++ b/utils.h
@@ -100,8 +100,22 @@ bool is_special_ver_ndx(Elf64_Versym v);
 std::string special_ver_ndx_to_str(Elf_Versym v);
 
 template <class T>
-std::string HexString(T num, int length = 16) {
+inline std::string HexString(T num, int length = 16) {
     std::stringstream ss;
     ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << num;
+    return ss.str();
+}
+
+template <>
+inline std::string HexString<char*>(char* num, int length) {
+    std::stringstream ss;
+    ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << reinterpret_cast<uint64_t>(num);
+    return ss.str();
+}
+
+template <>
+inline std::string HexString<const char*>(const char* num, int length) {
+    std::stringstream ss;
+    ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << reinterpret_cast<const uint64_t>(num);
     return ss.str();
 }

--- a/utils.h
+++ b/utils.h
@@ -13,6 +13,9 @@
 
 #define SOLD_LOG_KEY_VALUE(key, value) " " << key << "=" << value
 #define SOLD_LOG_KEY(key) SOLD_LOG_KEY_VALUE(#key, key)
+#define SOLD_LOG_64BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 16))
+#define SOLD_LOG_32BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 8))
+#define SOLD_LOG_16BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 4))
 
 #define Elf_Ehdr Elf64_Ehdr
 #define Elf_Phdr Elf64_Phdr
@@ -72,7 +75,9 @@ struct Syminfo {
     Elf_Sym* sym;
 };
 
+std::string ShowRelocationType(int type);
 std::ostream& operator<<(std::ostream& os, const Syminfo& s);
+std::ostream& operator<<(std::ostream& os, const Elf_Rel& s);
 
 struct TLS {
     struct Data {


### PR DESCRIPTION
As I said in https://github.com/shinh/sold/pull/54, sold couldn't handle accesses to TLS variables only with R_X86_64_DTPMOD64. This type of access is called the Local Dynamic model (https://docs.oracle.com/cd/E19253-01/817-1984/6mhm7plbj/index.html ). To handle this model, I changed for sold to rewrite offsets of TLS variables which are embedded in ELF files. 

I didn't handle relocations of R_X86_64_TPOFF64 because they exist only in libpthread.so, libm.so, libc.so, libgomp.so and librt.so and we exclude all of them in the default setting. You can check it with `./relocation-list-up.sh libtorch_cpu.so R_X86_64_TPOFF64`.