### PR TITLE
Parse EH frame header

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Install requirements
-      run: sudo apt install ninja-build
+      run: sudo apt install ninja-build libdwarf-dev
     - name: CMake
       run: mkdir build && cd build && cmake -GNinja ..
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,12 @@ add_executable(
     )
 target_link_libraries(print_version sold_lib glog)
 
+add_executable(
+    print_ehframe
+    print_ehframe.cc
+    )
+target_link_libraries(print_ehframe sold_lib glog)
+
 add_subdirectory(tests)
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/CTestCustom.cmake ${CMAKE_CURRENT_BINARY_DIR})

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,676 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.
+
+

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# TODO
+## How to build
+You need `libdwarf-dev` package.
 
-- TLS
-- aarch64
-- exe
-- 32
+## TODO
+- TLS in executables
+- AArch64
+- x86-32
 
 ## Failed tests
 - setjmp-gcc
 - tls-bss-g++
 - tls-bss-gcc
-- static-in-function-g++
 
 ## Test with Docker
 ```

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -426,6 +426,33 @@ void ELFBinary::ParseEHFrameHeader(size_t off, size_t size) {
         eh_frame_header_.cies.emplace_back(cie);
     }
 }
+
+std::string ELFBinary::ShowEHFrame() {
+    std::stringstream ss;
+
+    ss << "version: " << HexString(eh_frame_header_.version) << "\n";
+    ss << "eh_frame_ptr_enc: " << ShowDW_EH_PE(eh_frame_header_.eh_frame_ptr_enc) << "\n";
+    ss << "fde_count_enc: " << ShowDW_EH_PE(eh_frame_header_.fde_count_enc) << "\n";
+    ss << "table_enc: " << ShowDW_EH_PE(eh_frame_header_.table_enc) << "\n";
+    ss << "eh_frame_ptr: " << HexString(eh_frame_header_.eh_frame_ptr) << "\n";
+    ss << "fde_count: " << eh_frame_header_.fde_count << "\n";
+    for (int i = 0; i < eh_frame_header_.fde_count; i++) {
+        ss << "---------- table[" << i << "] ----------\n";
+        ss << "initial_loc: " << HexString(eh_frame_header_.table[i].initial_loc) << "\n";
+        ss << "fde_ptr: " << HexString(eh_frame_header_.table[i].fde_ptr) << "\n";
+        ss << "cie.length: " << HexString(eh_frame_header_.cies[i].length) << "\n";
+        ss << "cie.CIE_id: " << HexString(eh_frame_header_.cies[i].CIE_id) << "\n";
+        ss << "cie.version: " << HexString(eh_frame_header_.cies[i].version) << "\n";
+        ss << "cie.FDE_encoding: " << ShowDW_EH_PE(eh_frame_header_.cies[i].FDE_encoding) << "\n";
+        ss << "cie.LSDA_encoding: " << ShowDW_EH_PE(eh_frame_header_.cies[i].LSDA_encoding) << "\n";
+        ss << "fde.length: " << HexString(eh_frame_header_.fdes[i].length) << "\n";
+        ss << "fde.CIE_delta: " << HexString(eh_frame_header_.fdes[i].CIE_delta) << "\n";
+        ss << "fde.initial_loc: " << HexString(eh_frame_header_.fdes[i].initial_loc) << "\n";
+    }
+
+    return ss.str();
+}
+
 void ELFBinary::ParseDynamic(size_t off, size_t size) {
     size_t dyn_size = sizeof(Elf_Dyn);
     CHECK(size % dyn_size == 0);

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -344,8 +344,8 @@ void ELFBinary::ParseEHFrameHeader(size_t off, size_t size) {
                   << SOLD_LOG_32BITS(AddrFromOffset(off)) << SOLD_LOG_32BITS(AddrFromOffset(off) + e.fde_ptr)
                   << SOLD_LOG_32BITS(OffsetFromAddr(AddrFromOffset(off) + e.fde_ptr));
 
-        FDE fde = {};
-        CIE cie = {};
+        EHFrameHeader::FDE fde = {};
+        EHFrameHeader::CIE cie = {};
         cie.FDE_encoding = DW_EH_PE_SOLD_DUMMY;
         cie.LSDA_encoding = DW_EH_PE_SOLD_DUMMY;
 

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -306,25 +306,23 @@ void ELFBinary::ParsePhdrs() {
 void ELFBinary::ParseEHFrameHeader(size_t off, size_t size) {
     const char* const efh_base = head_ + off;
     int efh_offset = 0;
+    auto efh_read = [efh_base, &efh_offset](auto* p) {
+        memcpy(p, efh_base + efh_offset, sizeof(*p));
+        efh_offset += sizeof(*p);
+    };
 
-    eh_frame_header_.version = *(efh_base + efh_offset);
-    efh_offset += sizeof(eh_frame_header_.version);
-    eh_frame_header_.eh_frame_ptr_enc = *(efh_base + efh_offset);
-    efh_offset += sizeof(eh_frame_header_.eh_frame_ptr_enc);
-    eh_frame_header_.fde_count_enc = *(efh_base + efh_offset);
-    efh_offset += sizeof(eh_frame_header_.fde_count_enc);
-    eh_frame_header_.table_enc = *(efh_base + efh_offset);
-    efh_offset += sizeof(eh_frame_header_.table_enc);
+    efh_read(&eh_frame_header_.version);
+    efh_read(&eh_frame_header_.eh_frame_ptr_enc);
+    efh_read(&eh_frame_header_.fde_count_enc);
+    efh_read(&eh_frame_header_.table_enc);
 
     CHECK(eh_frame_header_.version == 1);
     CHECK(eh_frame_header_.eh_frame_ptr_enc == (DW_EH_PE_sdata4 | DW_EH_PE_pcrel));
     CHECK(eh_frame_header_.fde_count_enc == DW_EH_PE_udata4);
     CHECK(eh_frame_header_.table_enc == (DW_EH_PE_sdata4 | DW_EH_PE_datarel));
 
-    eh_frame_header_.eh_frame_ptr = *reinterpret_cast<const int32_t*>(efh_base + efh_offset);
-    efh_offset += sizeof(eh_frame_header_.eh_frame_ptr);
-    eh_frame_header_.fde_count = *reinterpret_cast<const uint32_t*>(efh_base + efh_offset);
-    efh_offset += sizeof(eh_frame_header_.fde_count);
+    efh_read(&eh_frame_header_.eh_frame_ptr);
+    efh_read(&eh_frame_header_.fde_count);
 
     LOG(INFO) << "ParseEHFrameHeader" << SOLD_LOG_KEY(off) << SOLD_LOG_KEY(size) << SOLD_LOG_8BITS(eh_frame_header_.version)
               << SOLD_LOG_DWEHPE(eh_frame_header_.eh_frame_ptr_enc) << SOLD_LOG_DWEHPE(eh_frame_header_.fde_count_enc)
@@ -334,10 +332,10 @@ void ELFBinary::ParseEHFrameHeader(size_t off, size_t size) {
     CHECK(efh_offset + eh_frame_header_.fde_count * (sizeof(int32_t) * 2) <= size)
         << SOLD_LOG_KEY(efh_offset + eh_frame_header_.fde_count * (sizeof(int32_t) * 2)) << SOLD_LOG_KEY(size);
 
-    for (int i = 0; i < eh_frame_header_.fde_count; i++, efh_offset += sizeof(int32_t) * 2) {
+    for (int i = 0; i < eh_frame_header_.fde_count; i++) {
         EHFrameHeader::FDETableEntry e;
-        e.initial_loc = *reinterpret_cast<const int32_t*>(efh_base + efh_offset);
-        e.fde_ptr = *reinterpret_cast<const int32_t*>(efh_base + efh_offset + sizeof(int32_t));
+        efh_read(&e.initial_loc);
+        efh_read(&e.fde_ptr);
         eh_frame_header_.table.emplace_back(e);
 
         LOG(INFO) << SOLD_LOG_32BITS(e.initial_loc) << SOLD_LOG_32BITS(e.fde_ptr) << SOLD_LOG_32BITS(off + e.fde_ptr)
@@ -351,55 +349,58 @@ void ELFBinary::ParseEHFrameHeader(size_t off, size_t size) {
 
         const char* const fde_base = head_ + OffsetFromAddr(AddrFromOffset(off) + e.fde_ptr);
         int fde_offset = 0;
+        auto fde_read = [fde_base, &fde_offset](auto* p) {
+            memcpy(p, fde_base + fde_offset, sizeof(*p));
+            fde_offset += sizeof(*p);
+        };
 
-        fde.length = *reinterpret_cast<const uint32_t*>(fde_base + fde_offset);
-        fde_offset += sizeof(uint32_t);
+        fde_read(&fde.length);
         if (fde.length == 0xffffffff) {
-            fde.extended_length = *reinterpret_cast<const uint64_t*>(fde_base + fde_offset);
-            fde_offset += sizeof(uint64_t);
+            fde_read(&fde.extended_length);
         }
-        fde.CIE_delta = *reinterpret_cast<const int32_t*>(fde_base + fde_offset);
-        fde_offset += sizeof(int32_t);
+        fde_read(&fde.CIE_delta);
 
         // fde_base + fde_offset - sizeof(int32_t) is the address of fde.CIE_delta.
-        const char* cie_head = head_ + OffsetFromAddr(AddrFromOffset(fde_base + fde_offset - sizeof(int32_t) - head_) - fde.CIE_delta);
+        const char* const cie_base =
+            head_ + OffsetFromAddr(AddrFromOffset(fde_base + fde_offset - sizeof(int32_t) - head_) - fde.CIE_delta);
+        int cie_offset = 0;
+        auto cie_read = [cie_base, &cie_offset](auto* p) {
+            memcpy(p, cie_base + cie_offset, sizeof(*p));
+            cie_offset += sizeof(*p);
+        };
         uint32_t utmp;
         int32_t stmp;
 
-        cie.length = *reinterpret_cast<const uint32_t*>(cie_head);
-        cie_head += sizeof(uint32_t);
-        cie.CIE_id = *reinterpret_cast<const int32_t*>(cie_head);
-        cie_head += sizeof(int32_t);
-        cie.version = *reinterpret_cast<const uint8_t*>(cie_head);
-        cie_head += sizeof(uint8_t);
-        cie.aug_str = cie_head;
-        while (*cie_head != '\0') cie_head++;
-        cie_head++;
-        cie_head = read_uleb128(cie_head, &utmp);  // Skip code alignment factor
-        cie_head = read_sleb128(cie_head, &stmp);  // Skip data alignment factor
+        cie_read(&cie.length);
+        cie_read(&cie.CIE_id);
+        cie_read(&cie.version);
+        cie.aug_str = cie_base + cie_offset;
+        while (*(cie_base + cie_offset) != '\0') cie_offset++;
+        cie_offset++;
+        cie_offset = read_uleb128(reinterpret_cast<const char*>(cie_base + cie_offset), &utmp) - cie_base;  // Skip code alignment factor
+        cie_offset = read_sleb128(reinterpret_cast<const char*>(cie_base + cie_offset), &stmp) - cie_base;  // Skip data alignment factor
+        cie_offset = read_uleb128(reinterpret_cast<const char*>(cie_base + cie_offset), &utmp) - cie_base;  // Skip augmentation factor
 
         const char* aug_head = cie.aug_str;
-        cie_head = read_uleb128(cie_head, &utmp);  // Skip augmentation length.
-
         if (*aug_head == 'z') {
             aug_head++;
-            cie_head++;
-            LOG(INFO) << SOLD_LOG_8BITS(*cie_head) << SOLD_LOG_KEY(*aug_head);
+            cie_offset++;
+
+            LOG(INFO) << SOLD_LOG_8BITS(*(cie_base + cie_offset)) << SOLD_LOG_KEY(*aug_head);
 
             // Copy from sysdeps/generic/unwind-dw2-fde.c in glibc
             while (1) {
                 if (*aug_head == 'R') {
-                    cie.FDE_encoding = *cie_head;
-                    cie_head++;
+                    cie_read(&cie.FDE_encoding);
                 } else if (*aug_head == 'P') {
                     /* Personality encoding and pointer.  */
                     /* ??? Avoid dereferencing indirect pointers, since we're
                        faking the base address.  Gotta keep DW_EH_PE_aligned
                        intact, however.  */
-                    cie_head = read_encoded_value_with_base(*cie_head & 0x7F, 0, cie_head + 1, &utmp);
+                    cie_offset =
+                        read_encoded_value_with_base(*(cie_base + cie_offset) & 0x7F, 0, cie_base + cie_offset + 1, &utmp) - cie_base;
                 } else if (*aug_head == 'L') {
-                    cie.LSDA_encoding = *cie_head;
-                    cie_head++;
+                    cie_read(&cie.LSDA_encoding);
                 } else {
                     if (*aug_head != '\0') {
                         LOG(WARNING) << "unknown augmentation" << SOLD_LOG_KEY(*aug_head) << SOLD_LOG_8BITS(*aug_head);
@@ -410,8 +411,7 @@ void ELFBinary::ParseEHFrameHeader(size_t off, size_t size) {
             }
         }
 
-        fde.initial_loc = *reinterpret_cast<const int32_t*>(fde_base + fde_offset);
-        fde_offset += sizeof(int32_t);
+        fde_read(&fde.initial_loc);
 
         LOG(INFO) << "ParseEHFrameHeader table[" << i << "] = {" << SOLD_LOG_32BITS(e.initial_loc) << SOLD_LOG_32BITS(e.fde_ptr)
                   << "} FDE = {" << SOLD_LOG_32BITS(fde.length) << SOLD_LOG_64BITS(fde.extended_length) << SOLD_LOG_32BITS(fde.CIE_delta)

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -102,12 +102,10 @@ public:
     void PrintVersyms();
 
     std::string ShowDynSymtab();
-
     std::string ShowDtRela();
-
     std::string ShowVersion();
-
     std::string ShowTLS();
+    std::string ShowEHFrame();
 
     std::pair<std::string, std::string> GetVersion(int index, const std::map<std::string, std::string>& filename_to_soname);
 

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -8,6 +8,41 @@
 #include <map>
 #include <memory>
 
+struct CIE {
+    uint32_t length;
+    int32_t CIE_id;
+    uint8_t version;
+    const char* aug_str;
+    uint8_t FDE_encoding;
+    uint8_t LSDA_encoding;
+};
+
+struct FDE {
+    uint32_t length;
+    uint64_t extended_length;
+    int32_t CIE_delta;
+    int32_t initial_loc;
+};
+
+struct EHFrameHeader {
+    struct FDETableEntry {
+        int32_t initial_loc;
+        int32_t fde_ptr;
+    };
+
+    uint8_t version;
+    uint8_t eh_frame_ptr_enc;
+    uint8_t fde_count_enc;
+    uint8_t table_enc;
+
+    int32_t eh_frame_ptr;
+    uint32_t fde_count;
+
+    std::vector<FDETableEntry> table;
+    std::vector<FDE> fdes;
+    std::vector<CIE> cies;
+};
+
 class ELFBinary {
 public:
     ELFBinary(const std::string& filename, int fd, char* head, size_t size);
@@ -81,9 +116,8 @@ public:
 
 private:
     void ParsePhdrs();
-
+    void ParseEHFrameHeader(size_t off, size_t size);
     void ParseDynamic(size_t off, size_t size);
-
     void ParseFuncArray(uintptr_t* array, uintptr_t size, std::vector<uintptr_t>* out);
 
     const std::string filename_;
@@ -97,6 +131,8 @@ private:
     Elf_Phdr* tls_{nullptr};
     const char* strtab_{nullptr};
     Elf_Sym* symtab_{nullptr};
+
+    EHFrameHeader eh_frame_header_;
 
     std::vector<std::string> neededs_;
     // This is the name specified in the DT_SONAME field.

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -8,26 +8,26 @@
 #include <map>
 #include <memory>
 
-struct CIE {
-    uint32_t length;
-    int32_t CIE_id;
-    uint8_t version;
-    const char* aug_str;
-    uint8_t FDE_encoding;
-    uint8_t LSDA_encoding;
-};
-
-struct FDE {
-    uint32_t length;
-    uint64_t extended_length;
-    int32_t CIE_delta;
-    int32_t initial_loc;
-};
-
 struct EHFrameHeader {
     struct FDETableEntry {
         int32_t initial_loc;
         int32_t fde_ptr;
+    };
+
+    struct CIE {
+        uint32_t length;
+        int32_t CIE_id;
+        uint8_t version;
+        const char* aug_str;
+        uint8_t FDE_encoding;
+        uint8_t LSDA_encoding;
+    };
+
+    struct FDE {
+        uint32_t length;
+        uint64_t extended_length;
+        int32_t CIE_delta;
+        int32_t initial_loc;
     };
 
     uint8_t version;

--- a/print_ehframe.cc
+++ b/print_ehframe.cc
@@ -1,0 +1,23 @@
+//
+// print_ehframe
+//
+// This program shows .eh_frame_hdr
+//
+
+#include "elf_binary.h"
+
+#include <iostream>
+
+int main(int argc, const char* argv[]) {
+    google::InitGoogleLogging(argv[0]);
+    google::InstallFailureSignalHandler();
+
+    if (argc != 2) {
+        std::cerr << "Usage: " << argv[0] << " <in-elf>\nThis program shows .eh_frame_hdr." << std::endl;
+        return 1;
+    }
+
+    auto b = ReadELF(argv[1]);
+    std::cout << b->ShowEHFrame();
+    return 0;
+}

--- a/ubuntu18.04.Dockerfile
+++ b/ubuntu18.04.Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 RUN apt-get update
-RUN apt-get install -y ninja-build cmake gcc g++ git
+RUN apt-get install -y ninja-build cmake gcc g++ git libdwarf-dev
 COPY . /sold
 WORKDIR /sold
 RUN rm -rf build

--- a/ubuntu20.04.Dockerfile
+++ b/ubuntu20.04.Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get install -y ninja-build cmake gcc g++ git
+RUN apt-get install -y ninja-build cmake gcc g++ git libdwarf-dev
 COPY . /sold
 WORKDIR /sold
 RUN rm -rf build

--- a/utils.cc
+++ b/utils.cc
@@ -39,6 +39,70 @@ std::ostream& operator<<(std::ostream& os, const Syminfo& s) {
     return os;
 }
 
+std::string ShowDW_EH_PE(uint8_t type) {
+    if (type == DW_EH_PE_omit) {
+        return "DW_EH_PE_omit";
+    }
+
+    std::string ret;
+
+    switch (type & 0xf) {
+        case DW_EH_PE_absptr:
+            ret = "DW_EH_PE_absptr";
+            break;
+        case DW_EH_PE_uleb128:
+            ret = "DW_EH_PE_uleb128";
+            break;
+        case DW_EH_PE_udata2:
+            ret = "DW_EH_PE_udata2";
+            break;
+        case DW_EH_PE_udata4:
+            ret = "DW_EH_PE_udata4";
+            break;
+        case DW_EH_PE_udata8:
+            ret = "DW_EH_PE_udata8";
+            break;
+        case DW_EH_PE_sleb128:
+            ret = "DW_EH_PE_sleb128";
+            break;
+        case DW_EH_PE_sdata2:
+            ret = "DW_EH_PE_sdata2";
+            break;
+        case DW_EH_PE_sdata4:
+            ret = "DW_EH_PE_sdata4";
+            break;
+        case DW_EH_PE_sdata8:
+            ret = "DW_EH_PE_sdata8";
+            break;
+    }
+
+    switch (type & 0xf0) {
+        case DW_EH_PE_pcrel:
+            ret += " + DW_EH_PE_pcrel";
+            break;
+        case DW_EH_PE_textrel:
+            ret += " + DW_EH_PE_textrel";
+            break;
+        case DW_EH_PE_datarel:
+            ret += " + DW_EH_PE_datarel";
+            break;
+        case DW_EH_PE_funcrel:
+            ret += " + DW_EH_PE_funcrel";
+            break;
+        case DW_EH_PE_aligned:
+            ret += " + DW_EH_PE_aligned";
+            break;
+    }
+
+    if (type == DW_EH_PE_SOLD_DUMMY) {
+        ret = "DW_EH_PE_SOLD_DUMMY(0xEE)";
+    } else if (ret == "") {
+        ret = HexString(type, 2);
+    }
+
+    return ret;
+}
+
 std::string ShowRelocationType(int type) {
     switch (type) {
         case R_X86_64_NONE:

--- a/utils.cc
+++ b/utils.cc
@@ -216,3 +216,121 @@ std::string special_ver_ndx_to_str(Elf64_Versym versym) {
         exit(1);
     }
 }
+
+// Copy from sysdeps/generic/unwind-pe.h in glibc
+const char* read_uleb128(const char* p, uint32_t* val) {
+    unsigned int shift = 0;
+    unsigned char byte;
+    uint32_t result;
+
+    result = 0;
+    do {
+        byte = *p++;
+        result |= (byte & 0x7f) << shift;
+        shift += 7;
+    } while (byte & 0x80);
+
+    *val = result;
+    return p;
+}
+
+// Copy from sysdeps/generic/unwind-pe.h in glibc
+const char* read_sleb128(const char* p, int32_t* val) {
+    unsigned int shift = 0;
+    unsigned char byte;
+    int32_t result;
+
+    result = 0;
+    do {
+        byte = *p++;
+        result |= (byte & 0x7f) << shift;
+        shift += 7;
+    } while (byte & 0x80);
+
+    /* Sign-extend a negative value.  */
+    if (shift < 8 * sizeof(result) && (byte & 0x40) != 0) result |= -(1L << shift);
+
+    *val = (int32_t)result;
+    return p;
+}
+
+// Copy from sysdeps/generic/unwind-pe.h in glibc
+typedef unsigned sold_Unwind_Internal_Ptr __attribute__((__mode__(__pointer__)));
+#define DW_EH_PE_indirect 0x80
+
+const char* read_encoded_value_with_base(unsigned char encoding, sold_Unwind_Ptr base, const char* p, uint32_t* val) {
+    union unaligned {
+        void* ptr;
+        unsigned u2 __attribute__((mode(HI)));
+        unsigned u4 __attribute__((mode(SI)));
+        unsigned u8 __attribute__((mode(DI)));
+        signed s2 __attribute__((mode(HI)));
+        signed s4 __attribute__((mode(SI)));
+        signed s8 __attribute__((mode(DI)));
+    } __attribute__((__packed__));
+
+    union unaligned* u = (union unaligned*)p;
+    sold_Unwind_Internal_Ptr result;
+
+    if (encoding == DW_EH_PE_aligned) {
+        sold_Unwind_Internal_Ptr a = (sold_Unwind_Internal_Ptr)p;
+        a = (a + sizeof(void*) - 1) & -sizeof(void*);
+        result = *(sold_Unwind_Internal_Ptr*)a;
+        p = (char*)(a + sizeof(void*));
+    } else {
+        switch (encoding & 0x0f) {
+            case DW_EH_PE_absptr:
+                result = (sold_Unwind_Internal_Ptr)u->ptr;
+                p += sizeof(void*);
+                break;
+
+            case DW_EH_PE_uleb128: {
+                uint32_t tmp;
+                p = read_uleb128(p, &tmp);
+                result = (sold_Unwind_Internal_Ptr)tmp;
+            } break;
+
+            case DW_EH_PE_sleb128: {
+                int32_t tmp;
+                p = read_sleb128(p, &tmp);
+                result = (sold_Unwind_Internal_Ptr)tmp;
+            } break;
+
+            case DW_EH_PE_udata2:
+                result = u->u2;
+                p += 2;
+                break;
+            case DW_EH_PE_udata4:
+                result = u->u4;
+                p += 4;
+                break;
+            case DW_EH_PE_udata8:
+                result = u->u8;
+                p += 8;
+                break;
+
+            case DW_EH_PE_sdata2:
+                result = u->s2;
+                p += 2;
+                break;
+            case DW_EH_PE_sdata4:
+                result = u->s4;
+                p += 4;
+                break;
+            case DW_EH_PE_sdata8:
+                result = u->s8;
+                p += 8;
+                break;
+            default:
+                LOG(FATAL) << SOLD_LOG_8BITS(encoding & 0x0f);
+        }
+
+        if (result != 0) {
+            result += ((encoding & 0x70) == DW_EH_PE_pcrel ? (sold_Unwind_Internal_Ptr)u : base);
+            if (encoding & DW_EH_PE_indirect) result = *(sold_Unwind_Internal_Ptr*)result;
+        }
+    }
+
+    *val = result;
+    return p;
+}

--- a/utils.h
+++ b/utils.h
@@ -16,6 +16,7 @@
 #define SOLD_LOG_64BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 16))
 #define SOLD_LOG_32BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 8))
 #define SOLD_LOG_16BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 4))
+#define SOLD_LOG_8BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 2))
 
 #define Elf_Ehdr Elf64_Ehdr
 #define Elf_Phdr Elf64_Phdr
@@ -100,22 +101,13 @@ bool is_special_ver_ndx(Elf64_Versym v);
 std::string special_ver_ndx_to_str(Elf_Versym v);
 
 template <class T>
-inline std::string HexString(T num, int length = 16) {
+inline std::string HexString(T num, int length = -1) {
+    if (length == -1) {
+        length = sizeof(T) * 2;
+    }
     std::stringstream ss;
-    ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << num;
+    ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << +num;
     return ss.str();
 }
 
-template <>
-inline std::string HexString<char*>(char* num, int length) {
-    std::stringstream ss;
-    ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << reinterpret_cast<uint64_t>(num);
-    return ss.str();
-}
 
-template <>
-inline std::string HexString<const char*>(const char* num, int length) {
-    std::stringstream ss;
-    ss << "0x" << std::uppercase << std::setfill('0') << std::setw(length) << std::hex << reinterpret_cast<const uint64_t>(num);
-    return ss.str();
-}

--- a/utils.h
+++ b/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <elf.h>
+#include <libdwarf/dwarf.h>
 
 #include <cassert>
 #include <iomanip>
@@ -17,6 +18,7 @@
 #define SOLD_LOG_32BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 8))
 #define SOLD_LOG_16BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 4))
 #define SOLD_LOG_8BITS(key) SOLD_LOG_KEY_VALUE(#key, HexString(key, 2))
+#define SOLD_LOG_DWEHPE(type) SOLD_LOG_KEY_VALUE(#type, ShowDW_EH_PE(type))
 
 #define Elf_Ehdr Elf64_Ehdr
 #define Elf_Phdr Elf64_Phdr
@@ -40,6 +42,9 @@
 #define ELF_R_SYM(val) ELF64_R_SYM(val)
 #define ELF_R_TYPE(val) ELF64_R_TYPE(val)
 #define ELF_R_INFO(sym, type) ELF64_R_INFO(sym, type)
+
+// 0xee is never used as a valid DWARF Exception Header value
+#define DW_EH_PE_SOLD_DUMMY 0xee
 
 // Although there is no description of VERSYM_HIDDEN in glibc, you can find it
 // in binutils source code.
@@ -77,6 +82,7 @@ struct Syminfo {
 };
 
 std::string ShowRelocationType(int type);
+std::string ShowDW_EH_PE(uint8_t type);
 std::ostream& operator<<(std::ostream& os, const Syminfo& s);
 std::ostream& operator<<(std::ostream& os, const Elf_Rel& s);
 

--- a/utils.h
+++ b/utils.h
@@ -116,4 +116,8 @@ inline std::string HexString(T num, int length = -1) {
     return ss.str();
 }
 
+const char* read_uleb128(const char* p, uint32_t* val);
+const char* read_sleb128(const char* p, int32_t* val);
 
+typedef unsigned sold_Unwind_Ptr __attribute__((__mode__(__word__)));
+const char* read_encoded_value_with_base(unsigned char encoding, sold_Unwind_Ptr base, const char* p, uint32_t* val);


### PR DESCRIPTION
The main change of this PR is `ELFBinary::ParseEHFrameHeader` in https://github.com/shinh/sold/pull/55/commits/1c047428b70a98dcc71b32a512905e6b28bf5dbf. It parses exception information following from the `PT_GNU_EH_FRAME` segment not using the information from any sections.

A `PT_GNU_EH_FRAME` segment has some meta-informations on FDE(Frame Description Entry)s and a binary search table. This table has pointers to each FDEs [1]. `ELFBinary::ParseEHFrameHeader` finds FDEs using these pointers. After that, it parses FDEs following this format [2].

`print_ehframe` is a CLI of `ELFBinary::ParseEHFrameHeader`. I have checked that `print_ehframe` works well for all depending shared objects of `libtorch.so`.

References
[1]: https://refspecs.linuxfoundation.org/LSB_1.3.0/gLSB/gLSB/ehframehdr.html
[2]: https://refspecs.linuxfoundation.org/LSB_3.0.0/LSB-PDA/LSB-PDA/ehframechpt.html