### PR TITLE
Refactor DecideOffset

### DIFF
--- a/sold.cc
+++ b/sold.cc
@@ -328,6 +328,19 @@ void Sold::EmitGnuHash(FILE* fp) {
     }
 }
 
+uintptr_t Sold::TLSMemSize() const {
+    static uintptr_t s = 0;
+    if (s != 0) return s;
+    for (ELFBinary* bin : link_binaries_) {
+        for (Elf_Phdr* phdr : bin->phdrs()) {
+            if (phdr->p_type == PT_TLS) {
+                s += phdr->p_memsz;
+            }
+        }
+    }
+    return s;
+}
+
 // Decide locations for each linked shared objects
 // TODO(akawashiro) Is the initial value of offset optimal?
 void Sold::DecideOffsets() {


### PR DESCRIPTION
We could not call  `DecideOffset` before building TLS because it depended on `Sold::tls_`. When it comes to appending `PT_GNU_FH_FRAME` or `PT_LOAD` after TLS template image, this restriction complicates the code.

So I make `Sold::TLSMemSize` and `Sold::EHFrameSize` so that we can call `DecideOffset` before building `Sold::tls_` and `Sold::ehframe_builder_`.