### PR TITLE
Order of link_binaries_

### DIFF
--- a/sold.cc
+++ b/sold.cc
@@ -767,7 +767,7 @@ std::vector<ELFBinary*> TopologicalSort(std::vector<std::pair<std::string, ELFBi
             --k_it;
         }
         if (i_it == buf.end() || ++i_it == buf.end()) break;
-        for (auto it = buf.begin(); it != buf.end(); it++) std::get<2>(*it) = 0;
+        for (auto it = i_it; it != buf.end(); it++) std::get<2>(*it) = 0;
     next:;
     }
 

--- a/sold.cc
+++ b/sold.cc
@@ -738,6 +738,7 @@ std::vector<std::string> Sold::GetLibraryPaths(const ELFBinary* binary) {
     return library_paths;
 }
 
+// This implementation is compatible with _dl_sort_maps in glibc/elf/dl-sort-maps.c.
 std::vector<ELFBinary*> TopologicalSort(std::vector<std::pair<std::string, ELFBinary*>> link_binaries_buf) {
     if (link_binaries_buf.size() < 1) {
         return {};

--- a/sold.cc
+++ b/sold.cc
@@ -423,16 +423,16 @@ void Sold::CollectArrays() {
         ELFBinary* bin = *iter;
         uintptr_t offset = offsets_[bin];
         for (uintptr_t ptr : bin->init_array()) {
-            init_array_.push_back(ptr + offset);
+            init_array_.emplace_back(ptr + offset);
         }
     }
     // TODO(akawashiro) In case of executables, this code causes SEGV. I don't
     // kwow the reason.
-    if (!is_executable_) init_array_.push_back(mprotect_offset_);
+    if (!is_executable_) init_array_.emplace_back(mprotect_offset_);
     for (ELFBinary* bin : link_binaries_) {
         uintptr_t offset = offsets_[bin];
         for (uintptr_t ptr : bin->fini_array()) {
-            fini_array_.push_back(ptr + offset);
+            fini_array_.emplace_back(ptr + offset);
         }
     }
     LOG(INFO) << "Array numbers: init_array=" << init_array_.size() << " fini_array=" << fini_array_.size();

--- a/sold.cc
+++ b/sold.cc
@@ -736,7 +736,7 @@ std::vector<std::string> Sold::GetLibraryPaths(const ELFBinary* binary) {
     return library_paths;
 }
 
-std::vector<ELFBinary*> ToplologicalSort(std::map<std::string, ELFBinary*> needed_to_bin) {
+std::vector<ELFBinary*> TopologicalSort(std::map<std::string, ELFBinary*> needed_to_bin) {
     std::vector<ELFBinary*> ret;
     std::queue<std::string> next_node;
     std::map<std::string, int> n_incoming_edge;

--- a/sold.cc
+++ b/sold.cc
@@ -740,7 +740,6 @@ std::vector<std::string> Sold::GetLibraryPaths(const ELFBinary* binary) {
 void Sold::ResolveLibraryPaths(const ELFBinary* root_binary) {
     // We should search for shared objects in BFS order.
     std::queue<const ELFBinary*> bfs_queue;
-    std::set<std::string> pushed_sonames;
 
     bfs_queue.push(root_binary);
 
@@ -767,12 +766,6 @@ void Sold::ResolveLibraryPaths(const ELFBinary* root_binary) {
             if (!library) {
                 LOG(FATAL) << "Library " << needed << " not found";
                 abort();
-            }
-
-            if (pushed_sonames.find(library->soname()) != pushed_sonames.end()) {
-                LOG(INFO) << SOLD_LOG_KEY(library->name())
-                          << " is not linked because we have already linked another shared object with the same soname.";
-                continue;
             }
 
             // Register (filename, soname)

--- a/sold.h
+++ b/sold.h
@@ -375,7 +375,7 @@ private:
 
     std::vector<std::string> GetLibraryPaths(const ELFBinary* binary);
 
-    void ResolveLibraryPaths(const ELFBinary* root_binary);
+    void ResolveLibraryPaths(ELFBinary* root_binary);
 
     bool Exists(const std::string& filename) {
         struct stat st;


### PR DESCRIPTION
According to https://refspecs.linuxbase.org/elf/gabi4+/ch5.dynamic.html#init_fini, we must initialize shared objects in the topological order. To achieve this, I make the order of `link_binaries_` topological.
