### PR TITLE
Fix a bug on the offset of eh_frame

### DIFF
--- a/sold.cc
+++ b/sold.cc
@@ -59,11 +59,11 @@ void Sold::Link(const std::string& out_filename) {
     }
     BuildArrays();
     BuildDynamic();
-    BuildEHFrameHeader();
     BuildMprotect();
 
     strtab_.Freeze();
     BuildLoads();
+    BuildEHFrameHeader();
 
     shdr_.RegisterShdr(GnuHashOffset(), GnuHashSize(), ShdrBuilder::ShdrType::GnuHash);
     shdr_.RegisterShdr(SymtabOffset(), SymtabSize(), ShdrBuilder::ShdrType::Dynsym, sizeof(Elf_Sym));

--- a/sold.h
+++ b/sold.h
@@ -118,7 +118,7 @@ private:
         return s;
     }
 
-    uintptr_t EHFrameOffset() const { return TLSOffset() + TLSFileSize(); }
+    uintptr_t EHFrameOffset() const { return AlignNext(TLSOffset() + TLSFileSize()); }
     // We emit EHFrame whenever the number of FDEs is 0.
     uintptr_t EHFrameSize() const {
         static uintptr_t s = 0;
@@ -276,6 +276,7 @@ private:
     }
 
     void EmitEHFrame(FILE* fp) {
+        EmitPad(fp, EHFrameOffset());
         CHECK(ftell(fp) == EHFrameOffset());
         LOG(INFO) << SOLD_LOG_BITS(ftell(fp)) << SOLD_LOG_BITS(EHFrameOffset()) << SOLD_LOG_BITS(ehframe_builder_.Size());
         ehframe_builder_.Emit(fp);

--- a/sold_main.cc
+++ b/sold_main.cc
@@ -25,6 +25,7 @@ Options:
 -i, --input-file INPUT_FILE     Specify the ELF file to output
 -e, --exclude-so EXCLUDE_FILE   Specify the ELF file to exclude (e.g. libmax.so) 
 --section-headers               Emit section headers
+--check-output                  Check the output using sold itself
 
 The last argument is interpreted as SOURCE_FILE when -i option isn't given.
 )" << std::endl;
@@ -39,6 +40,7 @@ int main(int argc, char* const argv[]) {
         {"output-file", required_argument, nullptr, 'o'},
         {"exclude-so", required_argument, nullptr, 'e'},
         {"section-headers", no_argument, nullptr, 1},
+        {"check-output", no_argument, nullptr, 2},
         {0, 0, 0, 0},
     };
 
@@ -46,12 +48,16 @@ int main(int argc, char* const argv[]) {
     std::string output_file;
     std::vector<std::string> exclude_sos;
     bool emit_section_header = false;
+    bool check_output = false;
 
     int opt;
     while ((opt = getopt_long(argc, argv, "hi:o:e:", long_options, nullptr)) != -1) {
         switch (opt) {
             case 1:
                 emit_section_header = true;
+                break;
+            case 2:
+                check_output = true;
                 break;
             case 'e':
                 exclude_sos.push_back(optarg);
@@ -82,5 +88,9 @@ int main(int argc, char* const argv[]) {
 
     Sold sold(input_file, exclude_sos, emit_section_header);
     sold.Link(output_file);
+
+    if (check_output) {
+        Sold check(output_file, exclude_sos, emit_section_header);
+    }
     return 0;
 }


### PR DESCRIPTION
- I had forgot to call `AlignNext()` in `EHFrameOffset()`.
- I had made mistake the order between `BuildEHFrameHeader()` and `BuildLoads()`. Because `BuildEHFrameHeader()` depends on `BuildLoads()` via `EHFrameOffset()` and `TLSOffset()`, we must call it after  `BuildLoads()`.

I made `--check-output` option because we can prevent such bugs if we check the output using sold itself.