### PR TITLE
Fix bugs in AddrFromOffset and OffsetFromAddr (formarly Overlap between TLS template image and GNU_EH_FRAME)

### DIFF
--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -561,7 +561,7 @@ void ELFBinary::ParseFuncArray(uintptr_t* array, uintptr_t size, std::vector<uin
 
 Elf_Addr ELFBinary::OffsetFromAddr(Elf_Addr addr) const {
     for (Elf_Phdr* phdr : loads_) {
-        if (phdr->p_vaddr <= addr && addr <= phdr->p_vaddr + phdr->p_memsz) {
+        if (phdr->p_vaddr <= addr && addr < phdr->p_vaddr + phdr->p_memsz) {
             return addr - phdr->p_vaddr + phdr->p_offset;
         }
     }
@@ -570,7 +570,7 @@ Elf_Addr ELFBinary::OffsetFromAddr(Elf_Addr addr) const {
 
 Elf_Addr ELFBinary::AddrFromOffset(Elf_Addr offset) const {
     for (Elf_Phdr* phdr : loads_) {
-        if (phdr->p_offset <= offset && offset <= phdr->p_offset + phdr->p_filesz) {
+        if (phdr->p_offset <= offset && offset < phdr->p_offset + phdr->p_filesz) {
             return offset - phdr->p_offset + phdr->p_vaddr;
         }
     }

--- a/sold.h
+++ b/sold.h
@@ -16,6 +16,7 @@
 #include <libgen.h>
 #include <sys/stat.h>
 
+#include <algorithm>
 #include <iostream>
 #include <map>
 #include <string>
@@ -115,6 +116,12 @@ private:
                 }
             }
         }
+
+        // Even if the size of the TLS initialization image in the output
+        // shared object is zero, we emit a dummy image of the page size.
+        // Without this dummy image, memory segments of TLS and EHFrameHeader
+        // overlap.
+        s = std::max(s, LINUX_PAGE_SIZE);
         return s;
     }
 

--- a/sold.h
+++ b/sold.h
@@ -16,7 +16,6 @@
 #include <libgen.h>
 #include <sys/stat.h>
 
-#include <algorithm>
 #include <iostream>
 #include <map>
 #include <string>
@@ -116,12 +115,6 @@ private:
                 }
             }
         }
-
-        // Even if the size of the TLS initialization image in the output
-        // shared object is zero, we emit a dummy image of the page size.
-        // Without this dummy image, memory segments of TLS and EHFrameHeader
-        // overlap.
-        s = std::max(s, LINUX_PAGE_SIZE);
         return s;
     }
 

--- a/tests/call_once-g++/test.sh
+++ b/tests/call_once-g++/test.sh
@@ -5,7 +5,7 @@ g++ -lpthread -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so -lpthread
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/dynamic_cast-g++/test.sh
+++ b/tests/dynamic_cast-g++/test.sh
@@ -5,7 +5,7 @@ g++ -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/exception-g++/test.sh
+++ b/tests/exception-g++/test.sh
@@ -3,7 +3,7 @@
 g++ -fPIC -shared -o libfuga.so -Wl,-soname,libfuga.so fuga.cc 
 g++ -fPIC -shared -o libhoge.so.original -Wl,-soname,libhoge.so hoge.cc libfuga.so
 g++ main.cc -o main libhoge.so.original libfuga.so
-LD_LIBRARY_PATH=. ../../build/sold -i libhoge.so.original -o libhoge.so.soldout
+LD_LIBRARY_PATH=. ../../build/sold -i libhoge.so.original -o libhoge.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf libhoge.so.soldout libhoge.so

--- a/tests/hello-g++/test.sh
+++ b/tests/hello-g++/test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 g++ hello.cc -o hello
-../../build/sold hello -o hello.out --section-headers
+../../build/sold hello -o hello.out --section-headers --check-output
 ./hello.out

--- a/tests/hello-gcc/test.sh
+++ b/tests/hello-gcc/test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 gcc hello.c -o hello
-../../build/sold hello -o hello.out --section-headers 
+../../build/sold hello -o hello.out --section-headers --check-output 
 ./hello.out

--- a/tests/inheritance-g++/test.sh
+++ b/tests/inheritance-g++/test.sh
@@ -5,7 +5,7 @@ g++ -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/just-return-g++/test.sh
+++ b/tests/just-return-g++/test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 g++ return.cc -o return
-../../build/sold return -o return.out --section-headers
+../../build/sold return -o return.out --section-headers --check-output
 ./return.out

--- a/tests/just-return-gcc/test.sh
+++ b/tests/just-return-gcc/test.sh
@@ -1,5 +1,5 @@
 #! /bin/bash
 
 gcc return.c -o return
-../../build/sold return -o return.out --section-headers
+../../build/sold return -o return.out --section-headers --check-output
 ./return.out

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -1,4 +1,7 @@
-#! /bin/bash -eu
+#! /bin/bash -u
+
+ret_code=0
+failed_tests=
 
 for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++
 do
@@ -6,5 +9,16 @@ do
     cd $dir
     echo =========== $dir ===========
     ./test.sh
+    if [ "$?" -ne 0 ];then
+        ret_code=1
+        if [ -z "${failed_tests}" ];then
+            failed_tests=${dir}
+        else
+            failed_tests=${dir},${failed_tests}
+        fi
+    fi
     popd
 done
+
+echo Failed tests: ${failed_tests} 
+exit ${ret_code}

--- a/tests/simple-lib-g++/test.sh
+++ b/tests/simple-lib-g++/test.sh
@@ -4,5 +4,5 @@ g++ -fPIC -c -o libmax.o libmax.cc
 g++ -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -o libmax.so libmax.o
 g++ -Wl,--hash-style=gnu -o main main.cc libmax.so
 
-LD_LIBRARY_PATH=. ../../build/sold main -o main.out --section-headers
+LD_LIBRARY_PATH=. ../../build/sold main -o main.out --section-headers --check-output
 LD_LIBRARY_PATH=. ./main.out

--- a/tests/simple-lib-gcc/test.sh
+++ b/tests/simple-lib-gcc/test.sh
@@ -4,5 +4,5 @@ gcc -fPIC -c -o libmax.o libmax.c
 gcc -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -o libmax.so libmax.o
 gcc -Wl,--hash-style=gnu -o main main.c libmax.so
 
-LD_LIBRARY_PATH=. ../../build/sold main -o main.out --section-headers
+LD_LIBRARY_PATH=. ../../build/sold main -o main.out --section-headers --check-output
 LD_LIBRARY_PATH=. ./main.out

--- a/tests/static-in-class-g++/test.sh
+++ b/tests/static-in-class-g++/test.sh
@@ -6,7 +6,7 @@ g++ -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/static-in-function-g++/test.sh
+++ b/tests/static-in-function-g++/test.sh
@@ -6,7 +6,7 @@ g++ -lpthread -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so -lpthread
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/tls-dlopen-gcc/test.sh
+++ b/tests/tls-dlopen-gcc/test.sh
@@ -5,7 +5,7 @@ gcc -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 gcc -Wl,--hash-style=gnu -o main main.c -ldl 
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/tls-lib-gcc-without-base/test.sh
+++ b/tests/tls-lib-gcc-without-base/test.sh
@@ -10,5 +10,5 @@ gcc -Wl,--hash-style=gnu -o main main.c original/lib.so original/base.so
 
 cp original/base.so sold_out/base.so
 
-LD_LIBRARY_PATH=original ../../build/sold original/lib.so -o sold_out/lib.so --section-headers --exclude-so base.so
+LD_LIBRARY_PATH=original ../../build/sold original/lib.so -o sold_out/lib.so --section-headers --exclude-so base.so --check-output
 LD_LIBRARY_PATH=sold_out ./main

--- a/tests/tls-lib-gcc/test.sh
+++ b/tests/tls-lib-gcc/test.sh
@@ -10,7 +10,7 @@ gcc -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o answer/lib.so lib.o base.
 # LD_LIBRARY_PATH=original gcc -Wl,--hash-style=gnu -o main main.c original/lib.so original/base.so
 # LD_LIBRARY_PATH=original ./main
 
-LD_LIBRARY_PATH=original ../../build/sold original/lib.so -o sold_out/lib.so --section-headers
+LD_LIBRARY_PATH=original ../../build/sold original/lib.so -o sold_out/lib.so --section-headers --check-output
  
 LD_LIBRARY_PATH=sold_out gcc -Wl,--hash-style=gnu -o main main.c sold_out/lib.so
 LD_LIBRARY_PATH=sold_out ./main

--- a/tests/tls-multiple-lib-gcc/test.sh
+++ b/tests/tls-multiple-lib-gcc/test.sh
@@ -12,7 +12,7 @@ gcc -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o answer/lib.so lib.o base2
 # LD_LIBRARY_PATH=original gcc -Wl,--hash-style=gnu -o main main.c original/lib.so original/base2.so original/base.so
 # LD_LIBRARY_PATH=original ./main
 
-LD_LIBRARY_PATH=original ../../build/sold original/lib.so -o sold_out/lib.so --section-headers
+LD_LIBRARY_PATH=original ../../build/sold original/lib.so -o sold_out/lib.so --section-headers --check-output
  
 LD_LIBRARY_PATH=sold_out gcc -Wl,--hash-style=gnu -o main main.c sold_out/lib.so
 LD_LIBRARY_PATH=sold_out ./main

--- a/tests/tls-multiple-module-g++/test.sh
+++ b/tests/tls-multiple-module-g++/test.sh
@@ -5,6 +5,6 @@ g++ -shared -fPIC -o libhoge.so -Wl,-soname,libhoge.so hoge.cc
 g++ -shared -fPIC -o libfugahoge.so.original fugahoge.cc libfuga.so libhoge.so
 g++ -o main main.cc -ldl 
 
-LD_LIBRARY_PATH=. ../../build/sold -i libfugahoge.so.original -o libfugahoge.so.soldout --section-headers
+LD_LIBRARY_PATH=. ../../build/sold -i libfugahoge.so.original -o libfugahoge.so.soldout --section-headers --check-output
 
 LD_LIBRARY_PATH=. ./main

--- a/tests/tls-thread-g++/test.sh
+++ b/tests/tls-thread-g++/test.sh
@@ -5,7 +5,7 @@ g++ -lpthread -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so -lpthread
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/typeid-g++/test.sh
+++ b/tests/typeid-g++/test.sh
@@ -5,7 +5,7 @@ g++ -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
 g++ -Wl,--hash-style=gnu -o main main.cc lib.so
 
 mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers
+../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
 
 # Use sold
 ln -sf lib.so.soldout lib.so

--- a/tests/version-gcc/test.sh
+++ b/tests/version-gcc/test.sh
@@ -10,7 +10,7 @@ gcc -Wl,--hash-style=gnu -shared -Wl,-soname,libmax.so -Wl,--version-script,libm
 ln -sf libmax.so.2 libmax.so
 gcc -Wl,--hash-style=gnu -o vertest2 vertest2.c libmax.so
 
-LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest1.out vertest1 --section-headers 
+LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest1.out vertest1 --section-headers --check-output 
 LD_LIBRARY_PATH=. ./vertest1.out
-LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest2.out vertest2  --section-headers
+LD_LIBRARY_PATH=. ../../build/sold -e libmax.so -o vertest2.out vertest2  --section-headers --check-output
 LD_LIBRARY_PATH=. ./vertest2.out

--- a/utils.h
+++ b/utils.h
@@ -126,6 +126,7 @@
 #define VERSYM_HIDDEN 0x8000
 #define VERSYM_VERSION 0x7fff
 
+static constexpr uintptr_t LINUX_PAGE_SIZE = 0x1000;
 static constexpr Elf_Versym NO_VERSION_INFO = 0xffff;
 
 std::vector<std::string> SplitString(const std::string& str, const std::string& sep);
@@ -136,7 +137,7 @@ template <class T>
 void Write(FILE* fp, const T& v) {
     CHECK(fwrite(&v, sizeof(v), 1, fp) == 1);
 }
-uintptr_t AlignNext(uintptr_t a, uintptr_t mask = 4095);
+uintptr_t AlignNext(uintptr_t a, uintptr_t mask = LINUX_PAGE_SIZE - 1);
 void WriteBuf(FILE* fp, const void* buf, size_t size);
 void EmitZeros(FILE* fp, uintptr_t cnt);
 void EmitPad(FILE* fp, uintptr_t to);

--- a/utils.h
+++ b/utils.h
@@ -126,7 +126,7 @@
 #define VERSYM_HIDDEN 0x8000
 #define VERSYM_VERSION 0x7fff
 
-static const Elf_Versym NO_VERSION_INFO = 0xffff;
+static constexpr Elf_Versym NO_VERSION_INFO = 0xffff;
 
 std::vector<std::string> SplitString(const std::string& str, const std::string& sep);
 


### PR DESCRIPTION
After I changed to use the `--check-output` option in all tests, I found some TLS related tests such as `tls-dlopen-gcc` failed. I found all of them have TLS variables without initial values and don't have TLS variables with initial values.

These crashes are because of the overlap of the TLS template image and GNU_EH_FRAME as you can see in the following. And the reason of the overlap is that `EHFrameOffset()` and `TLSOffset()` returned the same value  when `TLSFileSize()` is 0. I fixed it in https://github.com/shinh/sold/commit/0eb61cbabc88c993e1b7e9028a274e7e99a28d1a by emitting a dummy TLS image in order to make the size non-zero always.
```
> readelf -l lib.so.soldout

Elf file type is DYN (Shared object file)
Entry point 0x10001080
There are 12 program headers, starting at offset 64

Program Headers:
  Type           Offset             VirtAddr           PhysAddr
                 FileSiz            MemSiz              Flags  Align
  LOAD           0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000001000 0x0000000000001000  RW     0x1000
  DYNAMIC        0x00000000000006fd 0x00000000000006fd 0x00000000000006fd
                 0x0000000000000150 0x0000000000000150  RW     0x8
  LOAD           0x0000000000001000 0x0000000010000000 0x0000000010000000
                 0x00000000000006c0 0x00000000000006c0  RW     0x1000
  LOAD           0x0000000000002000 0x0000000010001000 0x0000000010001000
                 0x00000000000001c1 0x00000000000001c1  RWE    0x1000
  LOAD           0x0000000000003000 0x0000000010002000 0x0000000010002000
                 0x0000000000000100 0x0000000000000100  RW     0x1000
  LOAD           0x0000000000004dd0 0x0000000010003dd0 0x0000000010003dd0
                 0x0000000000000260 0x0000000000000268  RW     0x1000
  TLS            0x0000000000006000 0x0000000010005000 0x0000000010005000
                 0x0000000000000000 0x0000000000000008  R      0x1000
  LOAD           0x0000000000006000 0x0000000010005000 0x0000000010005000    <====
                 0x0000000000000000 0x0000000000000008  RW     0x1000
  GNU_EH_FRAME   0x0000000000006000 0x0000000010006000 0x0000000010006000    <====
                 0x000000000000002c 0x000000000000002c  R      0x1000
  LOAD           0x0000000000006000 0x0000000010006000 0x0000000010006000
                 0x000000000000002c 0x000000000000002c  RW     0x1000
  LOAD           0x0000000000007000 0x0000000010007000 0x0000000010007000
                 0x0000000000000030 0x0000000000000030  R E    0x1000
  GNU_STACK      0x0000000000000000 0x0000000000000000 0x0000000000000000
                 0x0000000000000000 0x0000000000000000  RW     0x10
 ```