### PR TITLE
Workaround for symbol lookup error

### DIFF
--- a/symtab_builder.cc
+++ b/symtab_builder.cc
@@ -193,7 +193,12 @@ void SymtabBuilder::Build(StrtabBuilder& strtab, VersionBuilder& version) {
 void SymtabBuilder::MergePublicSymbols(StrtabBuilder& strtab, VersionBuilder& version) {
     gnu_hash_.nbuckets = 1;
     CHECK(symtab_.size() <= std::numeric_limits<uint32_t>::max());
-    gnu_hash_.symndx = symtab_.size();
+    // TODO(akawashiro)
+    // Although gnu_hash_.symndx should be symtab_.size(), the loader cannot
+    // find a public symbol when it is pushed into symtab_ before
+    // MergePublicSymbols. So I set gnu_hash_.symndx to 1. This workaround
+    // makes the load process slow but doesn't have any other wrong effect.
+    gnu_hash_.symndx = 1;
     gnu_hash_.maskwords = 1;
     gnu_hash_.shift2 = 1;
 

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -3,7 +3,7 @@
 ret_code=0
 failed_tests=
 
-for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++
+for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++ stb_gnu_unique_tls
 do
     pushd `pwd`
     cd $dir

--- a/tests/stb_gnu_unique_tls/.gitignore
+++ b/tests/stb_gnu_unique_tls/.gitignore
@@ -1,0 +1,4 @@
+libunique.so
+libunique.so.original
+libunique.so.soldout
+main

--- a/tests/stb_gnu_unique_tls/main.cc
+++ b/tests/stb_gnu_unique_tls/main.cc
@@ -1,0 +1,5 @@
+int fn();
+
+int main() {
+    int x = fn();
+}

--- a/tests/stb_gnu_unique_tls/test.sh
+++ b/tests/stb_gnu_unique_tls/test.sh
@@ -7,4 +7,4 @@ mv libunique.so libunique.so.original
 ../../build/sold -i libunique.so.original -o libunique.so.soldout --section-headers --check-output
 ln -sf libunique.so.soldout libunique.so
 
-./main
+LD_LIBRARY_PATH=. ./main

--- a/tests/stb_gnu_unique_tls/test.sh
+++ b/tests/stb_gnu_unique_tls/test.sh
@@ -1,0 +1,10 @@
+#! /bin/bash -eux
+
+g++ -std=c++17 -fPIC -shared unique.cc -o libunique.so
+g++ -std=c++17 -o main main.cc libunique.so
+
+mv libunique.so libunique.so.original
+../../build/sold -i libunique.so.original -o libunique.so.soldout --section-headers --check-output
+ln -sf libunique.so.soldout libunique.so
+
+./main

--- a/tests/stb_gnu_unique_tls/unique.cc
+++ b/tests/stb_gnu_unique_tls/unique.cc
@@ -1,0 +1,50 @@
+#include <cstdio>
+
+// OK
+// No symbol
+// int inline_fn() {
+//     thread_local int c = 0;
+//     return c++;
+// }
+
+// OK
+// No symbol
+// static int inline_fn() {
+//     thread_local int c = 0;
+//     return c++;
+// }
+
+// OK
+// OBJECT UNIQUE
+// Deleted by sold
+// inline int inline_fn() {
+//     static int c = 0;
+//     return c++;
+// }
+
+// NG
+// TLS UNIQUE
+inline int inline_fn() {
+    thread_local int c = 0;
+    return c++;
+}
+
+// NG
+// TLS UNIQUE
+// inline thread_local int x = 10;
+// int inline_fn() {
+//     return x;
+// }
+
+// NG
+// TLS UNIQUE
+// inline int inline_fn() {
+//     static thread_local int c = 0;
+//     return c++;
+// }
+
+int fn() {
+    printf("%d\n", inline_fn());
+    printf("%d\n", inline_fn());
+    return 0;
+}


### PR DESCRIPTION
I found that `stb_gnu_unique_tls` failed because of a symbol lookup error. This because the index of `_ZZ9inline_fnvE1c` is smaller than `gnu_hash_.symndx` and the loader looks only at symbols after `gnu_hash_.symndx`.

I think there is two way to fix this bug.
- Fix `gnu_hash_.symndx`
- Fix the order of symbols

I decided to take the first one because it is easy to implement although it imposes some overhead on the loader.
```
# gnu_hash_.symndx before the bugfix

> readelf --dyn-syms libunique.so.soldout 

Symbol table '.dynsym' contains 10 entries:
   Num:    Value          Size Type    Bind   Vis      Ndx Name
     0: 0000000000000000     0 NOTYPE  LOCAL  DEFAULT  UND 
     1: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_deregisterTMCloneTab
     2: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND __gmon_start__
     3: 0000000000000000     4 TLS     UNIQUE DEFAULT    1 _ZZ9inline_fnvE1c
     4: 0000000000000000     0 NOTYPE  WEAK   DEFAULT  UND _ITM_registerTMCloneTable
     5: 0000000000000000     0 FUNC    WEAK   DEFAULT  UND __cxa_finalize@GLIBC_2.2.5 (2)
     6: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND printf@GLIBC_2.2.5 (2)
     7: 0000000000000000     0 FUNC    GLOBAL DEFAULT  UND __tls_get_addr@GLIBC_2.3 (3)
     8: 0000000010001159    63 FUNC    GLOBAL DEFAULT    1 _Z2fnv                        <=== `gnu_hash_.symndx`
     9: 0000000010001198    59 FUNC    WEAK   DEFAULT    1 _Z9inline_fnv
```

Reference.
- `l_gnu_chain_zero` is used as the head of hash
https://github.com/bminor/glibc/blob/f0419e6a10740a672b28e112c409ae24f5e890ab/elf/dl-lookup.c#L424
- When the loader set `l_gnu_chain_zero`, first `symbias` (`gnu_hash_.symndx` in our sold) symbols are ignored
https://github.com/bminor/glibc/blob/f0419e6a10740a672b28e112c409ae24f5e890ab/elf/dl-lookup.c#L975