### PR TITLE
Duplicated symbols cause a crash

### DIFF
--- a/listup_duplicated_syms.py
+++ b/listup_duplicated_syms.py
@@ -1,0 +1,26 @@
+# How to use
+# readelf --dyn-syms --wide hoge.so | python3 listup_duplicated_syms.py
+
+import sys
+
+alllines = sys.stdin.readlines()
+head = alllines[:3]
+lines = alllines[4:]
+symcount = dict()
+
+for l in lines:
+    ws = l.split()
+    name = ws[7].split('@')[0]
+    if name in symcount:
+        symcount[name] += 1
+    else:
+        symcount[name] = 1
+
+for l in head:
+    print(l, end="")
+
+for l in lines:
+    ws = l.split()
+    name = ws[7].split('@')[0]
+    if symcount[name] >= 2:
+        print(l,end="")

--- a/sold_main.cc
+++ b/sold_main.cc
@@ -90,7 +90,10 @@ int main(int argc, char* const argv[]) {
     sold.Link(output_file);
 
     if (check_output) {
+        std::string dummy = output_file + ".dummy-for-check-output";
         Sold check(output_file, exclude_sos, emit_section_header);
+        check.Link(dummy);
+        std::remove(dummy.c_str());
     }
     return 0;
 }

--- a/symtab_builder.cc
+++ b/symtab_builder.cc
@@ -204,9 +204,9 @@ void SymtabBuilder::MergePublicSymbols(StrtabBuilder& strtab, VersionBuilder& ve
     gnu_hash_.shift2 = 1;
 
     // exposed_sym_name_vers is used to avoid duplicated symbol
-    std::set<std::pair<std::string, std::string>> exposed_sym_name_vers;
+    std::set<std::tuple<std::string, std::string, std::string>> exposed_sym_name_vers;
     for (const Syminfo& s : exposed_syms_) {
-        CHECK(exposed_sym_name_vers.insert({s.name, s.version}).second) << SOLD_LOG_KEY(s.name);
+        CHECK(exposed_sym_name_vers.insert({s.name, s.soname, s.version}).second) << SOLD_LOG_KEY(s.name);
     }
 
     for (const auto& p : public_syms_) {
@@ -223,7 +223,7 @@ void SymtabBuilder::MergePublicSymbols(StrtabBuilder& strtab, VersionBuilder& ve
 
         Syminfo s{p.name, p.soname, p.version, p.versym, sym};
 
-        if (exposed_sym_name_vers.insert({s.name, s.version}).second) {
+        if (exposed_sym_name_vers.insert({s.name, s.soname, s.version}).second) {
             exposed_syms_.push_back(s);
             symtab_.push_back(*sym);
 

--- a/tests/call_once-g++/.gitignore
+++ b/tests/call_once-g++/.gitignore
@@ -1,3 +1,6 @@
+libfuga.so
+libfuga.so.original
+libfuga.so.soldout
+libhoge.so
 main
-lib.so.original
-lib.so.soldout
+sold.*

--- a/tests/call_once-g++/fuga.cc
+++ b/tests/call_once-g++/fuga.cc
@@ -1,0 +1,13 @@
+#include <thread>
+
+void thread_proc();
+
+void fuga() {
+    std::thread t1(thread_proc);
+    std::thread t2(thread_proc);
+    std::thread t3(thread_proc);
+
+    t1.join();
+    t2.join();
+    t3.join();
+}

--- a/tests/call_once-g++/hoge.cc
+++ b/tests/call_once-g++/hoge.cc
@@ -1,6 +1,6 @@
-#include "lib.h"
-
 #include <iostream>
+#include <mutex>
+#include <thread>
 
 std::once_flag once;
 
@@ -11,4 +11,3 @@ void init() {
 void thread_proc() {
     std::call_once(once, init);
 }
-

--- a/tests/call_once-g++/lib.h
+++ b/tests/call_once-g++/lib.h
@@ -1,4 +1,0 @@
-#include <mutex>
-#include <thread>
-
-void thread_proc();

--- a/tests/call_once-g++/main.cc
+++ b/tests/call_once-g++/main.cc
@@ -1,13 +1,5 @@
-#include <iostream>
-
-#include "lib.h"
+void fuga();
 
 int main() {
-    std::thread t1(thread_proc);
-    std::thread t2(thread_proc);
-    std::thread t3(thread_proc);
-
-    t1.join();
-    t2.join();
-    t3.join();
+    fuga();
 }

--- a/tests/call_once-g++/test.sh
+++ b/tests/call_once-g++/test.sh
@@ -2,7 +2,7 @@
 
 g++ -fPIC -shared -Wl,-soname,libhoge.so -o libhoge.so hoge.cc
 g++ -fPIC -shared -Wl,-soname,libfuga.so -o libfuga.so fuga.cc libhoge.so
-g++ -o main main.cc libfuga.so -pthread
+LD_LIBRARY_PATH=. g++ -o main main.cc libfuga.so -pthread
 
 mv libfuga.so libfuga.so.original
 GLOG_log_dir=. LD_LIBRARY_PATH=. ../../build/sold -i libfuga.so.original -o libfuga.so.soldout --section-headers

--- a/tests/call_once-g++/test.sh
+++ b/tests/call_once-g++/test.sh
@@ -1,16 +1,10 @@
-#! /bin/bash -eu
+#! /bin/bash -eux
 
-g++ -fPIC -c -o lib.o lib.cc
-g++ -lpthread -Wl,--hash-style=gnu -shared -Wl,-soname,lib.so -o lib.so lib.o
-g++ -Wl,--hash-style=gnu -o main main.cc lib.so -lpthread
+g++ -fPIC -shared -Wl,-soname,libhoge.so -o libhoge.so hoge.cc
+g++ -fPIC -shared -Wl,-soname,libfuga.so -o libfuga.so fuga.cc libhoge.so
+g++ -o main main.cc libfuga.so -pthread
 
-mv lib.so lib.so.original
-../../build/sold -i lib.so.original -o lib.so.soldout --section-headers --check-output
-
-# Use sold
-ln -sf lib.so.soldout lib.so
-
-# Use original
-# ln -sf lib.so.original lib.so
-
+mv libfuga.so libfuga.so.original
+GLOG_log_dir=. LD_LIBRARY_PATH=. ../../build/sold -i libfuga.so.original -o libfuga.so.soldout --section-headers
+ln -sf libfuga.so.soldout libfuga.so
 LD_LIBRARY_PATH=. ./main


### PR DESCRIPTION
After I change call_once-g++ test in https://github.com/shinh/sold/commit/0c10640b5db800bc2aaf631d3aaeab4cdcb87711, I found this test fails. The following code snippet is a part of the symbol table of libfuga.so at https://github.com/shinh/sold/commit/0c10640b5db800bc2aaf631d3aaeab4cdcb87711. As you can see, _ZSt15__once_callable appears twice. Furthermore, _ZSt15__once_callable appears as a defined symbol.

However, _ZSt15__once_callable must not be defined in libfuga.so because it is defined in libstdc++.so which is in EXCLUDE_SHARED_OBJECTS.

```
> readelf --dyn-syms --wide libfuga.so | grep __once_call 
    19: 0000000000000000     0 TLS     GLOBAL DEFAULT  UND _ZSt15__once_callable@GLIBCXX_3.4.11 (8)
    21: 0000000000000000     0 TLS     GLOBAL DEFAULT  UND _ZSt11__once_call@GLIBCXX_3.4.11 (8)
   110: 0000000000000000     0 TLS     GLOBAL DEFAULT    1 _ZSt15__once_callable@GLIBCXX_3.4.11 (8)
   111: 0000000000000000     0 TLS     GLOBAL DEFAULT    1 _ZSt11__once_call@GLIBCXX_3.4.11 (8)
```

So, I decided not to copy the same symbol twice https://github.com/shinh/sold/commit/7b62a286637f2aa6016022447c3489cd70156199. In addition to it, I added a check of duplicated symbols in https://github.com/shinh/sold/commit/7b62a286637f2aa6016022447c3489cd70156199.