### PR TITLE
Fix a bug of remapping address in TLS initialization images

### DIFF
--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -68,31 +68,21 @@ Range ELFBinary::GetRange() const {
 
 bool ELFBinary::IsVaddrInTLSData(uintptr_t vaddr) const {
     if (tls_) {
-        uint64_t a = reinterpret_cast<uint64_t>(vaddr);
-        uint64_t s = reinterpret_cast<uint64_t>(tls_->p_vaddr);
-        uint64_t e = reinterpret_cast<uint64_t>(tls_->p_vaddr + tls_->p_filesz);
-        bool ret = s <= a && a < e;
-        return ret;
+        return tls_->p_vaddr <= vaddr && vaddr < (tls_->p_vaddr + tls_->p_filesz);
     }
     return false;
 }
 
 bool ELFBinary::IsOffsetInTLSData(uintptr_t tls_offset) const {
-    uint64_t o = reinterpret_cast<uint64_t>(tls_offset);
-    uint64_t m = tls_ ? reinterpret_cast<uint64_t>(tls_->p_memsz) : 0;
-    uint64_t f = tls_ ? reinterpret_cast<uint64_t>(tls_->p_filesz) : 0;
-    if (tls_ && o < m) {
-        return o < f;
+    if (tls_ && tls_offset < tls_->p_memsz) {
+        return tls_offset < tls_->p_filesz;
     }
     LOG(FATAL) << SOLD_LOG_KEY(tls_) << SOLD_LOG_KEY(tls_offset);
 }
 
 bool ELFBinary::IsOffsetInTLSBSS(uintptr_t tls_offset) const {
-    uint64_t o = reinterpret_cast<uint64_t>(tls_offset);
-    uint64_t m = tls_ ? reinterpret_cast<uint64_t>(tls_->p_memsz) : 0;
-    uint64_t f = tls_ ? reinterpret_cast<uint64_t>(tls_->p_filesz) : 0;
-    if (tls_ && o < m) {
-        return f <= o;
+    if (tls_ && tls_offset < tls_->p_memsz) {
+        return tls_->p_filesz <= tls_offset;
     }
     LOG(FATAL) << SOLD_LOG_KEY(tls_) << SOLD_LOG_KEY(tls_offset);
 }

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -68,9 +68,9 @@ Range ELFBinary::GetRange() const {
 
 bool ELFBinary::IsVaddrInTLSData(uintptr_t vaddr) const {
     if (tls_) {
-        uint64_t a = vaddr;
-        uint64_t s = tls_->p_vaddr;
-        uint64_t e = tls_->p_vaddr + tls_->p_filesz;
+        uint64_t a = reinterpret_cast<uint64_t>(vaddr);
+        uint64_t s = reinterpret_cast<uint64_t>(tls_->p_vaddr);
+        uint64_t e = reinterpret_cast<uint64_t>(tls_->p_vaddr + tls_->p_filesz);
         bool ret = s <= a && a < e;
         return ret;
     }
@@ -78,9 +78,9 @@ bool ELFBinary::IsVaddrInTLSData(uintptr_t vaddr) const {
 }
 
 bool ELFBinary::IsOffsetInTLSData(uintptr_t tls_offset) const {
-    uint64_t o = tls_offset;
-    uint64_t m = tls_ ? tls_->p_memsz : 0;
-    uint64_t f = tls_ ? tls_->p_filesz : 0;
+    uint64_t o = reinterpret_cast<uint64_t>(tls_offset);
+    uint64_t m = tls_ ? reinterpret_cast<uint64_t>(tls_->p_memsz) : 0;
+    uint64_t f = tls_ ? reinterpret_cast<uint64_t>(tls_->p_filesz) : 0;
     if (tls_ && o < m) {
         return o < f;
     }
@@ -88,9 +88,9 @@ bool ELFBinary::IsOffsetInTLSData(uintptr_t tls_offset) const {
 }
 
 bool ELFBinary::IsOffsetInTLSBSS(uintptr_t tls_offset) const {
-    uint64_t o = tls_offset;
-    uint64_t m = tls_ ? tls_->p_memsz : 0;
-    uint64_t f = tls_ ? tls_->p_filesz : 0;
+    uint64_t o = reinterpret_cast<uint64_t>(tls_offset);
+    uint64_t m = tls_ ? reinterpret_cast<uint64_t>(tls_->p_memsz) : 0;
+    uint64_t f = tls_ ? reinterpret_cast<uint64_t>(tls_->p_filesz) : 0;
     if (tls_ && o < m) {
         return f <= o;
     }

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -66,23 +66,33 @@ Range ELFBinary::GetRange() const {
     return range;
 }
 
-bool ELFBinary::InTLS(uintptr_t offset) const {
+bool ELFBinary::IsVaddrInTLSData(uintptr_t vaddr) const {
     if (tls_) {
-        return tls_->p_vaddr <= offset && offset < tls_->p_vaddr + tls_->p_memsz;
+        uint64_t a = vaddr;
+        uint64_t s = tls_->p_vaddr;
+        uint64_t e = tls_->p_vaddr + tls_->p_filesz;
+        bool ret = s <= a && a < e;
+        return ret;
     }
     return false;
 }
 
-bool ELFBinary::InTLSData(uintptr_t tls_offset) const {
-    if (tls_ && tls_offset < tls_->p_memsz) {
-        return tls_offset < tls_->p_filesz;
+bool ELFBinary::IsOffsetInTLSData(uintptr_t tls_offset) const {
+    uint64_t o = tls_offset;
+    uint64_t m = tls_ ? tls_->p_memsz : 0;
+    uint64_t f = tls_ ? tls_->p_filesz : 0;
+    if (tls_ && o < m) {
+        return o < f;
     }
     LOG(FATAL) << SOLD_LOG_KEY(tls_) << SOLD_LOG_KEY(tls_offset);
 }
 
-bool ELFBinary::InTLSBSS(uintptr_t tls_offset) const {
-    if (tls_ && tls_offset < tls_->p_memsz) {
-        return (tls_->p_filesz <= tls_offset);
+bool ELFBinary::IsOffsetInTLSBSS(uintptr_t tls_offset) const {
+    uint64_t o = tls_offset;
+    uint64_t m = tls_ ? tls_->p_memsz : 0;
+    uint64_t f = tls_ ? tls_->p_filesz : 0;
+    if (tls_ && o < m) {
+        return f <= o;
     }
     LOG(FATAL) << SOLD_LOG_KEY(tls_) << SOLD_LOG_KEY(tls_offset);
 }

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -66,9 +66,9 @@ public:
 
     Range GetRange() const;
 
-    bool InTLS(uintptr_t offset) const;
-    bool InTLSData(uintptr_t offset) const;
-    bool InTLSBSS(uintptr_t offset) const;
+    bool IsVaddrInTLSData(uintptr_t vaddr) const;
+    bool IsOffsetInTLSData(uintptr_t offset) const;
+    bool IsOffsetInTLSBSS(uintptr_t offset) const;
 
     void ReadDynSymtab(const std::map<std::string, std::string>& filename_to_soname);
 

--- a/sold.cc
+++ b/sold.cc
@@ -156,10 +156,9 @@ void Sold::BuildLoads() {
     mprotect_file_offset_ = file_offset;
 
     for (const Load& load : loads_) {
-        LOG(INFO) << "PT_LOAD mapping: name=" << load.bin->name()
-                  << " vaddr=" << load.emit.p_vaddr << " memsz=" << load.emit.p_memsz
-                  << " offset=" << load.emit.p_offset << " filesz=" << load.emit.p_filesz
-                  << " orig_vaddr=" << load.orig->p_vaddr << " orig_offset=" << load.orig->p_offset;
+        LOG(INFO) << "PT_LOAD mapping: name=" << load.bin->name() << " vaddr=" << load.emit.p_vaddr << " memsz=" << load.emit.p_memsz
+                  << " offset=" << load.emit.p_offset << " filesz=" << load.emit.p_filesz << " orig_vaddr=" << load.orig->p_vaddr
+                  << " orig_offset=" << load.orig->p_offset;
     }
 }
 

--- a/sold.cc
+++ b/sold.cc
@@ -610,7 +610,7 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
             uint64_t* mod_on_got =
                 const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(bin->head() + bin->OffsetFromAddr(rel->r_offset)));
             uint64_t* offset_on_got = mod_on_got + 1;
-            const bool is_bss = bin->InTLSBSS(*offset_on_got);
+            const bool is_bss = bin->IsOffsetInTLSBSS(*offset_on_got);
 
             // We assume dl_tls_index exists in GOT. This struct is used as
             // the argument of __tls_get_addr.

--- a/sold.cc
+++ b/sold.cc
@@ -546,7 +546,7 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
     int type = ELF_R_TYPE(rel->r_info);
     const uintptr_t addend = rel->r_addend;
     Elf_Rel newrel = *rel;
-    if (bin->InTLS(rel->r_offset)) {
+    if (bin->IsVaddrInTLSData(rel->r_offset)) {
         const Elf_Phdr* tls = bin->tls();
         CHECK(tls);
         uintptr_t off = newrel.r_offset - tls->p_vaddr;

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -3,7 +3,7 @@
 ret_code=0
 failed_tests=
 
-for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++ stb_gnu_unique_tls setjmp-gcc
+for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++ stb_gnu_unique_tls setjmp-gcc tls-bss-gcc tls-bss-g++
 do
     pushd `pwd`
     cd $dir

--- a/tests/tls-bss-g++/main.cc
+++ b/tests/tls-bss-g++/main.cc
@@ -1,5 +1,4 @@
 #include <stdio.h>
-#include <threads.h>
 
 thread_local int tls_bss_i;
 

--- a/tests/tls-bss-gcc/main.c
+++ b/tests/tls-bss-gcc/main.c
@@ -1,7 +1,6 @@
 #include <stdio.h>
-#include <threads.h>
 
-thread_local int tls_bss_i;
+__thread int tls_bss_i;
 
 int main() {
     tls_bss_i = 2;


### PR DESCRIPTION
Because we bundle up TLS initialization images of multiple shared objects, we must remap addresses of relocations in them.  However, we made mistake on the sizes of TLS initialization images. While we used `p_memsz` as the size of TLS initialization images, we should use `p_filesz`. (https://github.com/shinh/sold/commit/634fb990b697ffa5df8d625d75b005e9f6bdb2d2 and https://github.com/shinh/sold/commit/05fb3fa21a7e7af45da772fd0a77e83452954ec7)

In addition to it, I rewrite `InTLS`, `InTLSData`, and `InTLSBSS` not to compare a pointer and an integer directly.