### PR TITLE
Exclude fini option

### DIFF
--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -37,7 +37,7 @@ int main(int argc, const char* argv[]) {
     }
 
     // This Sold class instrance is used only to get filename_to_soname map.
-    Sold sold(argv[1], {}, false);
+    Sold sold(argv[1], {}, {}, false);
 
     auto b = ReadELF(argv[1]);
     b->ReadDynSymtab(sold.filename_to_soname());

--- a/sold.h
+++ b/sold.h
@@ -34,7 +34,8 @@
 
 class Sold {
 public:
-    Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, bool emit_section_header);
+    Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, const std::vector<std::string>& exclude_finis,
+         bool emit_section_header);
 
     void Link(const std::string& out_filename);
 
@@ -419,6 +420,7 @@ private:
     std::unique_ptr<ELFBinary> main_binary_;
     std::vector<std::string> ld_library_paths_;
     std::vector<std::string> exclude_sos_;
+    std::vector<std::string> exclude_finis_;
     std::map<std::string, std::unique_ptr<ELFBinary>> libraries_;
     std::vector<ELFBinary*> link_binaries_;
     std::map<const ELFBinary*, uintptr_t> offsets_;

--- a/sold_main.cc
+++ b/sold_main.cc
@@ -26,6 +26,7 @@ Options:
 -e, --exclude-so EXCLUDE_FILE   Specify the ELF file to exclude (e.g. libmax.so) 
 --section-headers               Emit section headers
 --check-output                  Check the output using sold itself
+--exclude-from-fini             Do not use .fini_array of the ELF file
 
 The last argument is interpreted as SOURCE_FILE when -i option isn't given.
 )" << std::endl;
@@ -41,12 +42,14 @@ int main(int argc, char* const argv[]) {
         {"exclude-so", required_argument, nullptr, 'e'},
         {"section-headers", no_argument, nullptr, 1},
         {"check-output", no_argument, nullptr, 2},
+        {"exclude-from-fini", required_argument, nullptr, 3},
         {0, 0, 0, 0},
     };
 
     std::string input_file;
     std::string output_file;
     std::vector<std::string> exclude_sos;
+    std::vector<std::string> exclude_finis;
     bool emit_section_header = false;
     bool check_output = false;
 
@@ -58,6 +61,9 @@ int main(int argc, char* const argv[]) {
                 break;
             case 2:
                 check_output = true;
+                break;
+            case 3:
+                exclude_finis.push_back(optarg);
                 break;
             case 'e':
                 exclude_sos.push_back(optarg);
@@ -86,12 +92,12 @@ int main(int argc, char* const argv[]) {
         return 1;
     }
 
-    Sold sold(input_file, exclude_sos, emit_section_header);
+    Sold sold(input_file, exclude_sos, exclude_finis, emit_section_header);
     sold.Link(output_file);
 
     if (check_output) {
         std::string dummy = output_file + ".dummy-for-check-output";
-        Sold check(output_file, exclude_sos, emit_section_header);
+        Sold check(output_file, exclude_sos, exclude_finis, emit_section_header);
         check.Link(dummy);
         std::remove(dummy.c_str());
     }


### PR DESCRIPTION
I found some `.fini_array` causes SEGV for an unknown reason. For example, `.fini_array` of `libtorch_cpu.so` failed when it called after one of `libtorch_cuda.so`.

As a temporal solution, I made the `--exclude-from-fini` option. It excludes a given SO file from `.fini_array`. You can use it like the following.
```
sold -i libtorch_test.so.original -o libtorch_test.so.soldout --section-headers --exclude-from-fini libtorch_cpu.so
```