### PR TITLE
PT_TLS section also takes up memory space

### DIFF
--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -572,10 +572,8 @@ Elf_Addr ELFBinary::OffsetFromAddr(Elf_Addr addr) const {
             return addr - phdr->p_vaddr + phdr->p_offset;
         }
     }
-    if (tls() != nullptr) {
-        if (tls()->p_vaddr <= addr && addr < tls()->p_vaddr + tls()->p_memsz) {
-            return addr - tls()->p_vaddr + tls()->p_offset;
-        }
+    if (tls() != nullptr && tls()->p_vaddr == addr) {
+        return tls()->p_offset;
     }
     LOG(FATAL) << "Address " << HexString(addr, 16) << " cannot be resolved";
 }
@@ -586,12 +584,8 @@ Elf_Addr ELFBinary::AddrFromOffset(Elf_Addr offset) const {
             return offset - phdr->p_offset + phdr->p_vaddr;
         }
     }
-    if (tls() != nullptr) {
-        // I use `<=` in `offset <= tls()->p_offset + tls()->p_filesz` because
-        // `tls()->p_filesz` is 0 when no TLS variables have initial value.
-        if (tls()->p_offset <= offset && offset <= tls()->p_offset + tls()->p_filesz) {
-            return offset - tls()->p_offset + tls()->p_vaddr;
-        }
+    if (tls() != nullptr && tls()->p_offset == offset) {
+        return tls()->p_vaddr;
     }
     LOG(FATAL) << "Offset " << HexString(offset, 16) << " cannot be resolved";
 }


### PR DESCRIPTION
Because PT_TLS section also takes up memory space, we must consider when converting an address to an offset and vice versa.