### PR TITLE
Remove CHECK(bin->rel()) assertion

### DIFF
--- a/sold.h
+++ b/sold.h
@@ -350,7 +350,6 @@ private:
 
     void RelocateBinary(ELFBinary* bin) {
         CHECK(bin->symtab());
-        CHECK(bin->rel());
         RelocateSymbols(bin, bin->rel(), bin->num_rels());
         RelocateSymbols(bin, bin->plt_rel(), bin->num_plt_rels());
     }

--- a/sold.h
+++ b/sold.h
@@ -355,6 +355,7 @@ private:
     }
 
     void RelocateSymbols(ELFBinary* bin, const Elf_Rel* rels, size_t num) {
+        if (!rels) CHECK_EQ(0, num);
         uintptr_t offset = offsets_[bin];
         for (size_t i = 0; i < num; ++i) {
             // TODO(hamaji): Support non-x86-64 architectures.


### PR DESCRIPTION
I remove this assertion because some libraries such as libicudata.so have no relocations.
(I notice this when I tried to link clang.)