### PR TITLE
Workaround for libtorch test on aarch64

### DIFF
--- a/libtorch_test/CMakeLists.txt
+++ b/libtorch_test/CMakeLists.txt
@@ -15,14 +15,16 @@ add_library(torch_test SHARED torch_test.cc)
 target_link_libraries(torch_test PRIVATE "${TORCH_LIBRARIES}" -Wl,-soname,libtorch_test.so)
 set_target_properties(torch_test PROPERTIES SUFFIX ".so.original")
 
-# TODO(akawashiro): Remove exclude-from-fini option
+# TODO(akawashiro): Remove exclude-from-init and exclude-from-fini option
+# We exclude libtorch_cpu.so for x86-64.
+# We exclude liblapack.so and libblas.so for aarch64.
 add_custom_target(torch_test_soldout ALL
-    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.soldout --section-headers --check-output --exclude-from-fini libtorch_cpu.so && ln -sf libtorch_test.so.soldout libtorch_test.so
+    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.soldout --section-headers --check-output --exclude-from-fini libtorch_cpu.so --exclude-from-init liblapack.so --exclude-from-fini liblapack.so --exclude-from-init libblas.so --exclude-from-fini libblas.so && ln -sf libtorch_test.so.soldout libtorch_test.so
     DEPENDS torch_test sold
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(torch_test_soldout_wo_section EXCLUDE_FROM_ALL
-    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.wosection.soldout --check-output --exclude-from-fini libtorch_cpu.so
+    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.wosection.soldout --check-output --exclude-from-fini libtorch_cpu.so --exclude-from-init liblapack.so --exclude-from-fini liblapack.so --exclude-from-init libblas.so --exclude-from-fini libblas.so
     DEPENDS torch_test sold
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/libtorch_test/torch_test.cc
+++ b/libtorch_test/torch_test.cc
@@ -23,4 +23,10 @@ extern "C" void test() {
     auto r2 = at::convolution(x, w, c10::nullopt, c10::IntArrayRef({1, 1}), c10::IntArrayRef({0}), c10::IntArrayRef({1, 1}), false,
                               c10::IntArrayRef({0}), 1);
     SLOG() << SSHOW(r2.toString()) << std::endl;
+
+    SLOG() << "matmul test" << std::endl;
+    auto m1 = at::randn({128, 128}, at::kFloat);
+    auto m2 = at::randn({128, 128}, at::kFloat);
+    auto m3 = at::matmul(m1, m2);
+    SLOG() << SSHOW(m3.toString()) << std::endl;
 }

--- a/print_dynsymtab.cc
+++ b/print_dynsymtab.cc
@@ -37,7 +37,7 @@ int main(int argc, const char* argv[]) {
     }
 
     // This Sold class instrance is used only to get filename_to_soname map.
-    Sold sold(argv[1], {}, {}, {}, false);
+    Sold sold(argv[1], {}, {}, {}, {}, false);
 
     auto b = ReadELF(argv[1]);
     b->ReadDynSymtab(sold.filename_to_soname());

--- a/sold.cc
+++ b/sold.cc
@@ -20,9 +20,10 @@
 #include <queue>
 #include <set>
 
-Sold::Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, const std::vector<std::string>& exclude_finis,
-           const std::vector<std::string> custome_library_path, bool emit_section_header)
+Sold::Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, const std::vector<std::string>& exclude_inits,
+           const std::vector<std::string>& exclude_finis, const std::vector<std::string> custome_library_path, bool emit_section_header)
     : exclude_sos_(exclude_sos),
+      exclude_inits_(exclude_inits),
       exclude_finis_(exclude_finis),
       custome_library_path_(custome_library_path),
       emit_section_header_(emit_section_header) {
@@ -440,6 +441,8 @@ void Sold::CollectTLS() {
 void Sold::CollectArrays() {
     for (auto iter = link_binaries_.rbegin(); iter != link_binaries_.rend(); ++iter) {
         ELFBinary* bin = *iter;
+        if (std::any_of(exclude_inits_.cbegin(), exclude_inits_.cend(), [bin](const auto s) { return HasPrefix(bin->soname(), s); }))
+            continue;
         uintptr_t offset = offsets_[bin];
         for (uintptr_t ptr : bin->init_array()) {
             init_array_.emplace_back(ptr + offset);

--- a/sold.h
+++ b/sold.h
@@ -34,8 +34,8 @@
 
 class Sold {
 public:
-    Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, const std::vector<std::string>& exclude_finis,
-         const std::vector<std::string> custome_library_path, bool emit_section_header);
+    Sold(const std::string& elf_filename, const std::vector<std::string>& exclude_sos, const std::vector<std::string>& exclude_inits,
+         const std::vector<std::string>& exclude_finis, const std::vector<std::string> custome_library_path, bool emit_section_header);
 
     void Link(const std::string& out_filename);
 
@@ -436,6 +436,7 @@ private:
     std::unique_ptr<ELFBinary> main_binary_;
     std::vector<std::string> ld_library_paths_;
     const std::vector<std::string> exclude_sos_;
+    const std::vector<std::string> exclude_inits_;
     const std::vector<std::string> exclude_finis_;
     const std::vector<std::string> custome_library_path_;
     std::map<std::string, std::unique_ptr<ELFBinary>> libraries_;

--- a/sold_main.cc
+++ b/sold_main.cc
@@ -27,6 +27,7 @@ Options:
 -L, --custom-library-path PATH  Use PATH instead of the default path such as /usr/lib
 --section-headers               Emit section headers
 --check-output                  Check the output using sold itself
+--exclude-from-init             Do not use .init_array of the ELF file
 --exclude-from-fini             Do not use .fini_array of the ELF file
 
 The last argument is interpreted as SOURCE_FILE when -i option isn't given.
@@ -44,13 +45,15 @@ int main(int argc, char* const argv[]) {
         {"custom-library-path", required_argument, nullptr, 'L'},
         {"section-headers", no_argument, nullptr, 1},
         {"check-output", no_argument, nullptr, 2},
-        {"exclude-from-fini", required_argument, nullptr, 3},
+        {"exclude-from-init", required_argument, nullptr, 3},
+        {"exclude-from-fini", required_argument, nullptr, 4},
         {0, 0, 0, 0},
     };
 
     std::string input_file;
     std::string output_file;
     std::vector<std::string> exclude_sos;
+    std::vector<std::string> exclude_inits;
     std::vector<std::string> exclude_finis;
     std::vector<std::string> custome_library_path;
     bool emit_section_header = false;
@@ -66,6 +69,9 @@ int main(int argc, char* const argv[]) {
                 check_output = true;
                 break;
             case 3:
+                exclude_inits.push_back(optarg);
+                break;
+            case 4:
                 exclude_finis.push_back(optarg);
                 break;
             case 'e':
@@ -98,12 +104,12 @@ int main(int argc, char* const argv[]) {
         return 1;
     }
 
-    Sold sold(input_file, exclude_sos, exclude_finis, custome_library_path, emit_section_header);
+    Sold sold(input_file, exclude_sos, exclude_inits, exclude_finis, custome_library_path, emit_section_header);
     sold.Link(output_file);
 
     if (check_output) {
         std::string dummy = output_file + ".dummy-for-check-output";
-        Sold check(output_file, exclude_sos, exclude_finis, custome_library_path, emit_section_header);
+        Sold check(output_file, exclude_sos, exclude_inits, exclude_finis, custome_library_path, emit_section_header);
         check.Link(dummy);
         std::remove(dummy.c_str());
     }

--- a/tests/call_once-g++/test.sh
+++ b/tests/call_once-g++/test.sh
@@ -2,7 +2,7 @@
 
 g++ -fPIC -shared -Wl,-soname,libhoge.so -o libhoge.so hoge.cc
 g++ -fPIC -shared -Wl,-soname,libfuga.so -o libfuga.so fuga.cc libhoge.so
-LD_LIBRARY_PATH=. g++ -o main main.cc libfuga.so -pthread
+LD_LIBRARY_PATH=. g++ -o main main.cc libfuga.so libhoge.so -pthread
 
 mv libfuga.so libfuga.so.original
 GLOG_log_dir=. LD_LIBRARY_PATH=. ../../build/sold -i libfuga.so.original -o libfuga.so.soldout --section-headers

--- a/tests/run-all-tests.sh
+++ b/tests/run-all-tests.sh
@@ -3,7 +3,14 @@
 unexpected_failed_tests=
 unexpected_succeeded_tests=
 
-for dir in hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++ stb_gnu_unique_tls setjmp-gcc tls-bss-gcc tls-bss-g++ hello-g++-aarch64 hello-gcc-aarch64 just-return-g++-aarch64 simple-lib-g++-aarch64 simple-lib-gcc-aarch64 version-gcc-aarch64 tls-bss-gcc-aarch64 tls-bss-g++-aarch64 just-return-gcc-aarch64 setjmp-gcc-aarch64 exception-g++-aarch64 typeid-g++-aarch64 inheritance-g++-aarch64 dynamic_cast-g++-aarch64 static-in-class-g++-aarch64 static-in-function-g++-aarch64 tls-lib-gcc-aarch64 stb_gnu_unique_tls-aarch64 tls-multiple-module-g++-aarch64 tls-dlopen-gcc-aarch64 call_once-g++-aarch64 tls-thread-g++-aarch64 tls-lib-gcc-without-base-aarch64
+testcases=(hello-g++ hello-gcc just-return-g++ just-return-gcc simple-lib-g++ simple-lib-gcc version-gcc tls-lib-gcc tls-lib-gcc-without-base tls-multiple-lib-gcc tls-thread-g++ call_once-g++ inheritance-g++ typeid-g++ dynamic_cast-g++ tls-dlopen-gcc static-in-function-g++ static-in-class-g++ tls-multiple-module-g++ exception-g++ stb_gnu_unique_tls setjmp-gcc tls-bss-gcc tls-bss-g++)
+
+if [ -z "$(uname -a | grep aarch64)" ]
+then
+    testcases+=(hello-g++-aarch64 hello-gcc-aarch64 just-return-g++-aarch64 simple-lib-g++-aarch64 simple-lib-gcc-aarch64 version-gcc-aarch64 tls-bss-gcc-aarch64 tls-bss-g++-aarch64 just-return-gcc-aarch64 setjmp-gcc-aarch64 exception-g++-aarch64 typeid-g++-aarch64 inheritance-g++-aarch64 dynamic_cast-g++-aarch64 static-in-class-g++-aarch64 static-in-function-g++-aarch64 tls-lib-gcc-aarch64 stb_gnu_unique_tls-aarch64 tls-multiple-module-g++-aarch64 tls-dlopen-gcc-aarch64 call_once-g++-aarch64 tls-thread-g++-aarch64 tls-lib-gcc-without-base-aarch64)
+fi
+
+for dir in ${testcases[@]}
 do
     pushd `pwd`
     cd $dir
@@ -20,21 +27,24 @@ do
 done
 
 # TODO(akawashiro): tls-multiple-lib-gcc-aarch64 fails on CI although it succeeds in containers.
-for dir in tls-multiple-lib-gcc-aarch64 
-do
-    pushd `pwd`
-    cd $dir
-    echo =========== $dir ===========
-    ./test.sh
-    if [ "$?" -eq 0 ];then
-        if [ -z "${unexpected_succeeded_tests}" ];then
-            unexpected_succeeded_tests=${dir}
-        else
-            unexpected_succeeded_tests=${unexpected_succeeded_tests},${dir}
+if [ -z "$(uname -a | grep aarch64)" ]
+then
+    for dir in tls-multiple-lib-gcc-aarch64 
+    do
+        pushd `pwd`
+        cd $dir
+        echo =========== $dir ===========
+        ./test.sh
+        if [ "$?" -eq 0 ];then
+            if [ -z "${unexpected_succeeded_tests}" ];then
+                unexpected_succeeded_tests=${dir}
+            else
+                unexpected_succeeded_tests=${unexpected_succeeded_tests},${dir}
+            fi
         fi
-    fi
-    popd
-done
+        popd
+    done
+fi
 
 echo Unexpected failed tests: ${unexpected_failed_tests} 
 echo Unexpected succeeded tests: ${unexpected_succeeded_tests}


### PR DESCRIPTION
With this PR, I confirmed `libtorch_test` passed on aarch64 machine (https://hub.docker.com/layers/multiarch/ubuntu-core/arm64-focal/images/sha256-0fb415a923a008be469295e786bb1407d5b9f0492562b87a8c6de1e462a5d48c?context=explore).

I implemented `--exclude-from-init` option as a workaround because `liblapack.so` and `liblapack.so` caused `illegal instruction`.