### PR TITLE
Fix arrays

### DIFF
--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -70,6 +70,18 @@ Range ELFBinary::GetRange() const {
     return range;
 }
 
+bool ELFBinary::IsAddrInInitarray(uintptr_t addr) const {
+    CHECK(init_array_addr_ != 0);
+    LOG(INFO) << SOLD_LOG_BITS(addr) << SOLD_LOG_BITS(init_array_addr_) << SOLD_LOG_BITS(init_arraysz_);
+    return reinterpret_cast<uintptr_t>(init_array_addr_) <= addr && addr < reinterpret_cast<uintptr_t>(init_array_addr_ + init_arraysz_);
+}
+
+bool ELFBinary::IsAddrInFiniarray(uintptr_t addr) const {
+    CHECK(fini_array_addr_ != 0);
+    LOG(INFO) << SOLD_LOG_BITS(addr) << SOLD_LOG_BITS(fini_array_addr_) << SOLD_LOG_BITS(fini_arraysz_);
+    return reinterpret_cast<uintptr_t>(fini_array_addr_) <= addr && addr < reinterpret_cast<uintptr_t>(fini_array_addr_ + fini_arraysz_);
+}
+
 bool ELFBinary::IsVaddrInTLSData(uintptr_t vaddr) const {
     if (tls_) {
         return tls_->p_vaddr <= vaddr && vaddr < (tls_->p_vaddr + tls_->p_filesz);
@@ -329,6 +341,11 @@ void ELFBinary::ParsePhdrs() {
             gnu_relro_ = phdr;
         }
     }
+
+    LOG(INFO) << SOLD_LOG_BITS(reinterpret_cast<uintptr_t>(init_array_offset_)) << SOLD_LOG_BITS(reinterpret_cast<uintptr_t>(head()));
+    LOG(INFO) << SOLD_LOG_BITS(reinterpret_cast<uintptr_t>(fini_array_offset_)) << SOLD_LOG_BITS(reinterpret_cast<uintptr_t>(head()));
+    if (init_array_offset_) init_array_addr_ = AddrFromOffset(reinterpret_cast<char*>(init_array_offset_) - head());
+    if (fini_array_offset_) fini_array_addr_ = AddrFromOffset(reinterpret_cast<char*>(fini_array_offset_) - head());
     CHECK(!phdrs_.empty());
 }
 
@@ -491,10 +508,6 @@ void ELFBinary::ParseDynamic(size_t off, size_t size) {
         dyns.push_back(dyn);
     }
 
-    uintptr_t* init_array{0};
-    uintptr_t init_arraysz{0};
-    uintptr_t* fini_array{0};
-    uintptr_t fini_arraysz{0};
     for (Elf_Dyn* dyn : dyns) {
         auto get_ptr = [this, dyn]() { return GetPtr(dyn->d_un.d_ptr); };
         if (dyn->d_tag == DT_STRTAB) {
@@ -521,13 +534,13 @@ void ELFBinary::ParseDynamic(size_t off, size_t size) {
             // TODO(hamaji): Support 32bit?
             CHECK(false);
         } else if (dyn->d_tag == DT_INIT_ARRAY) {
-            init_array = reinterpret_cast<uintptr_t*>(get_ptr());
+            init_array_offset_ = reinterpret_cast<uintptr_t*>(get_ptr());
         } else if (dyn->d_tag == DT_INIT_ARRAYSZ) {
-            init_arraysz = dyn->d_un.d_val;
+            init_arraysz_ = dyn->d_un.d_val;
         } else if (dyn->d_tag == DT_FINI_ARRAY) {
-            fini_array = reinterpret_cast<uintptr_t*>(get_ptr());
+            fini_array_offset_ = reinterpret_cast<uintptr_t*>(get_ptr());
         } else if (dyn->d_tag == DT_FINI_ARRAYSZ) {
-            fini_arraysz = dyn->d_un.d_val;
+            fini_arraysz_ = dyn->d_un.d_val;
         } else if (dyn->d_tag == DT_INIT) {
             init_ = dyn->d_un.d_ptr;
         } else if (dyn->d_tag == DT_FINI) {
@@ -546,8 +559,8 @@ void ELFBinary::ParseDynamic(size_t off, size_t size) {
     }
     CHECK(strtab_);
 
-    ParseFuncArray(init_array, init_arraysz, &init_array_);
-    ParseFuncArray(fini_array, fini_arraysz, &fini_array_);
+    ParseFuncArray(init_array_offset_, init_arraysz_, &init_array_);
+    ParseFuncArray(fini_array_offset_, fini_arraysz_, &fini_array_);
 
     for (Elf_Dyn* dyn : dyns) {
         if (dyn->d_tag == DT_NEEDED) {

--- a/elf_binary.cc
+++ b/elf_binary.cc
@@ -569,7 +569,7 @@ void ELFBinary::ParseFuncArray(uintptr_t* array, uintptr_t size, std::vector<uin
     }
 }
 
-Elf_Addr ELFBinary::OffsetFromAddr(Elf_Addr addr) const {
+Elf_Addr ELFBinary::OffsetFromAddr(const Elf_Addr addr) const {
     for (Elf_Phdr* phdr : loads_) {
         if (phdr->p_vaddr <= addr && addr < phdr->p_vaddr + phdr->p_memsz) {
             return addr - phdr->p_vaddr + phdr->p_offset;
@@ -581,7 +581,7 @@ Elf_Addr ELFBinary::OffsetFromAddr(Elf_Addr addr) const {
     LOG(FATAL) << "Address " << HexString(addr, 16) << " cannot be resolved";
 }
 
-Elf_Addr ELFBinary::AddrFromOffset(Elf_Addr offset) const {
+Elf_Addr ELFBinary::AddrFromOffset(const Elf_Addr offset) const {
     for (Elf_Phdr* phdr : loads_) {
         if (phdr->p_offset <= offset && offset < phdr->p_offset + phdr->p_filesz) {
             return offset - phdr->p_offset + phdr->p_vaddr;

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -92,8 +92,8 @@ public:
 
     std::pair<std::string, std::string> GetVersion(int index, const std::map<std::string, std::string>& filename_to_soname);
 
-    Elf_Addr OffsetFromAddr(Elf_Addr addr) const;
-    Elf_Addr AddrFromOffset(Elf_Addr offset) const;
+    Elf_Addr OffsetFromAddr(const Elf_Addr addr) const;
+    Elf_Addr AddrFromOffset(const Elf_Addr offset) const;
 
 private:
     void ParsePhdrs();

--- a/elf_binary.h
+++ b/elf_binary.h
@@ -59,12 +59,17 @@ public:
 
     uintptr_t init() const { return init_; }
     uintptr_t fini() const { return fini_; }
+    const uintptr_t init_array_addr() const { return init_array_addr_; };
+    const uintptr_t fini_array_addr() const { return fini_array_addr_; };
     const std::vector<uintptr_t>& init_array() const { return init_array_; }
     const std::vector<uintptr_t>& fini_array() const { return fini_array_; }
 
     const std::vector<Syminfo>& GetSymbolMap() const { return syms_; }
 
     Range GetRange() const;
+
+    bool IsAddrInInitarray(uintptr_t addr) const;
+    bool IsAddrInFiniarray(uintptr_t addr) const;
 
     bool IsVaddrInTLSData(uintptr_t vaddr) const;
     bool IsOffsetInTLSData(uintptr_t offset) const;
@@ -130,6 +135,13 @@ private:
 
     Elf_GnuHash* gnu_hash_{nullptr};
     Elf_Hash* hash_{nullptr};
+
+    uintptr_t* init_array_offset_{0};
+    uintptr_t init_arraysz_{0};
+    uintptr_t init_array_addr_{0};
+    uintptr_t* fini_array_offset_{0};
+    uintptr_t fini_array_addr_{0};
+    uintptr_t fini_arraysz_{0};
 
     uintptr_t init_{0};
     uintptr_t fini_{0};

--- a/libtorch_test/CMakeLists.txt
+++ b/libtorch_test/CMakeLists.txt
@@ -15,14 +15,13 @@ add_library(torch_test SHARED torch_test.cc)
 target_link_libraries(torch_test PRIVATE "${TORCH_LIBRARIES}" -Wl,-soname,libtorch_test.so)
 set_target_properties(torch_test PROPERTIES SUFFIX ".so.original")
 
-# TODO(akawashiro): Remove exclude-from-fini option
 add_custom_target(torch_test_soldout ALL
-    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.soldout --section-headers --check-output --exclude-from-fini libtorch_cpu.so && ln -sf libtorch_test.so.soldout libtorch_test.so
+    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.soldout --section-headers --check-output && ln -sf libtorch_test.so.soldout libtorch_test.so
     DEPENDS torch_test sold
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(torch_test_soldout_wo_section EXCLUDE_FROM_ALL
-    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.wosection.soldout --check-output --exclude-from-fini libtorch_cpu.so
+    COMMAND GLOG_log_dir=${CMAKE_CURRENT_BINARY_DIR} ${CMAKE_BINARY_DIR}/sold -i ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.original -o ${CMAKE_CURRENT_BINARY_DIR}/libtorch_test.so.wosection.soldout --check-output
     DEPENDS torch_test sold
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 

--- a/sold.cc
+++ b/sold.cc
@@ -559,154 +559,186 @@ void Sold::RelocateSymbol_x86_64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t o
 
     int type = ELF_R_TYPE(rel->r_info);
     const uintptr_t addend = rel->r_addend;
-    Elf_Rel newrel = *rel;
+    std::vector<Elf_Rel> newrels;
+
     if (bin->IsVaddrInTLSData(rel->r_offset)) {
+        Elf_Rel newrel = *rel;
         const Elf_Phdr* tls = bin->tls();
         CHECK(tls);
         uintptr_t off = newrel.r_offset - tls->p_vaddr;
         off = RemapTLS("reloc", bin, off);
         newrel.r_offset = off + tls_offset_;
+        newrels.emplace_back(newrel);
     } else {
+        Elf_Rel newrel = *rel;
         newrel.r_offset += offset;
+        newrels.emplace_back(newrel);
+    }
+
+    if (bin->IsAddrInInitarray(rel->r_offset)) {
+        Elf_Rel newrel = *rel;
+        CHECK(bin_to_init_array_offset_.find(bin) != bin_to_init_array_offset_.end()) << SOLD_LOG_KEY(bin->filename());
+
+        newrel.r_offset -= bin->init_array_addr();
+        newrel.r_offset += bin_to_init_array_offset_[bin];
+        LOG(INFO) << SOLD_LOG_BITS(bin->init_array_addr()) << SOLD_LOG_BITS(bin_to_init_array_offset_[bin])
+                  << SOLD_LOG_BITS(newrel.r_offset) << SOLD_LOG_BITS(newrel.r_addend) << SOLD_LOG_BITS(offset);
+        newrels.emplace_back(newrel);
+    } else if (bin->IsAddrInFiniarray(rel->r_offset)) {
+        Elf_Rel newrel = *rel;
+        CHECK(bin_to_fini_array_offset_.find(bin) != bin_to_fini_array_offset_.end()) << SOLD_LOG_KEY(bin->filename());
+
+        newrel.r_offset -= bin->fini_array_addr();
+        newrel.r_offset += bin_to_fini_array_offset_[bin];
+        LOG(INFO) << SOLD_LOG_BITS(bin->fini_array_addr()) << SOLD_LOG_BITS(bin_to_fini_array_offset_[bin])
+                  << SOLD_LOG_BITS(newrel.r_offset) << SOLD_LOG_BITS(newrel.r_addend) << SOLD_LOG_BITS(offset);
+        newrels.emplace_back(newrel);
     }
 
     LOG(INFO) << "Relocate " << bin->Str(sym->st_name) << " at " << rel->r_offset;
 
-    // Even if we found a defined symbol in src_syms_, we cannot
-    // erase the relocation entry. The address needs to be fixed at
-    // runtime by ASLR function so we set RELATIVE to these resolved symbols.
-    switch (type) {
-        case R_X86_64_RELATIVE: {
-            if (IsDefined(*sym)) {
-                LOG(WARNING) << "The symbol associated with R_X86_64_RELATIVE is defined. Because this relocation type doesn't need any "
-                                "symbol, something wrong may have happened.";
-            }
-            newrel.r_addend += offset;
-            break;
-        }
-
-        case R_X86_64_GLOB_DAT:
-        case R_X86_64_JUMP_SLOT: {
-            uintptr_t val_or_index;
-            if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
-                newrel.r_info = ELF_R_INFO(0, R_X86_64_RELATIVE);
-                newrel.r_addend = val_or_index;
-            } else {
-                newrel.r_info = ELF_R_INFO(val_or_index, type);
-            }
-            break;
-        }
-
-        case R_X86_64_64: {
-            uintptr_t val_or_index;
-            if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
-                newrel.r_info = ELF_R_INFO(0, R_X86_64_RELATIVE);
-                newrel.r_addend += val_or_index;
-            } else {
-                newrel.r_info = ELF_R_INFO(val_or_index, type);
-            }
-            break;
-        }
-
-        // TODO(akawashiro) Handle TLS variables in executables.
-        case R_X86_64_DTPMOD64: {
-            // TODO(akawashiro) Refactor out for Arch64
-            const std::string name = bin->Str(sym->st_name);
-            uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
-            newrel.r_info = ELF_R_INFO(index, type);
-
-            if (bin->tls() == NULL) {
-                LOG(INFO) << SOLD_LOG_64BITS(bin->tls()) << " is null. This relocation is TLS generic dynamic model.";
-                break;
-            }
-
-            uint64_t* mod_on_got =
-                const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(bin->head() + bin->OffsetFromAddr(rel->r_offset)));
-            uint64_t* offset_on_got = mod_on_got + 1;
-            const bool is_bss = bin->IsOffsetInTLSBSS(*offset_on_got);
-
-            // We assume dl_tls_index exists in GOT. This struct is used as
-            // the argument of __tls_get_addr.
-            //
-            // typedef struct dl_tls_index
-            // {
-            //   uint64_t ti_module; <--- mod_on_got
-            //   uint64_t ti_offset; <--- offset_on_got
-            // } tls_index;
-            //
-            // In TLS generic dynamic model, both ti_module and ti_offset are
-            // rewritten by R_X86_64_DTPMOD64 and R_X86_64_DTPOFF64,
-            // respectively.
-            //
-            // In TLS local dynamic model, the only ti_module is rewrite by
-            // R_X86_64_DTPMOD64 and ti_offset is fixed in the link process. We
-            // must rewrite the fixed ti_offset because we remap the TLS
-            // template.
-
-            std::vector<int> rewrite_rel_types;  // Type of relocations which rewrite ti_module.
-            for (size_t i = 0; i < bin->num_rels(); ++i) {
-                if (rel->r_offset + sizeof(uint64_t) <= bin->rel()[i].r_offset &&
-                    bin->rel()[i].r_offset < rel->r_offset + sizeof(uint64_t) + sizeof(uint64_t)) {
-                    rewrite_rel_types.emplace_back(ELF_R_TYPE(bin->rel()[i].r_info));
+    for (auto newrel : newrels) {
+        // Even if we found a defined symbol in src_syms_, we cannot
+        // erase the relocation entry. The address needs to be fixed at
+        // runtime by ASLR function so we set RELATIVE to these resolved symbols.
+        switch (type) {
+            case R_X86_64_RELATIVE: {
+                if (IsDefined(*sym)) {
+                    LOG(WARNING)
+                        << "The symbol associated with R_X86_64_RELATIVE is defined. Because this relocation type doesn't need any "
+                           "symbol, something wrong may have happened.";
                 }
-            }
-
-            CHECK(rewrite_rel_types.size() == 0 || (rewrite_rel_types.size() == 1 && rewrite_rel_types[0] == R_X86_64_DTPOFF64))
-                << SOLD_LOG_KEY(rewrite_rel_types.size()) << SOLD_LOG_KEY(ShowRelocationType(rewrite_rel_types[0]));
-
-            if (rewrite_rel_types.size() == 1) {
-                LOG(INFO) << "R_X86_64_DTPOFF64 exists next to R_X86_64_DTPMOD64. This relocation is TLS generic dynamic model.";
+                newrel.r_addend += offset;
                 break;
             }
 
-            LOG(INFO) << "R_X86_64_DTPMOD64 relocation in TLS local dynamic model. " << SOLD_LOG_KEY(*rel) << SOLD_LOG_KEY(newrel)
-                      << SOLD_LOG_64BITS(bin->OffsetFromAddr(rel->r_offset)) << SOLD_LOG_64BITS(*mod_on_got)
-                      << SOLD_LOG_64BITS(*offset_on_got) << SOLD_LOG_64BITS(bin->tls()->p_filesz) << SOLD_LOG_KEY(is_bss)
-                      << SOLD_LOG_64BITS(tls_.data[tls_.bin_to_index[bin]].file_offset)
-                      << SOLD_LOG_64BITS(tls_.data[tls_.bin_to_index[bin]].bss_offset);
-
-            CHECK(ELF_R_SYM(rel->r_info) == 0)
-                << "The symbol associated with R_X86_64_DTPMOD64 in TLS local dynamic model should be the dummy.";
-
-            if (is_bss) {
-                // TLS variables without initial values are remapped from
-                // [bin->tls()->p_filesz, bin->tls()->p_memsz) to
-                // [tls_.data[tls_.bin_to_index[bin]].bss_offset,
-                //  tls_.data[tls_.bin_to_index[bin]].bss_offset + bin->tls()->p_memsz - bin->tls()->p_filesz)
-                *offset_on_got += tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz;
-            } else {
-                // TLS variables with initial values are remapped from
-                // [0, bin->tls()->p_filesz) to
-                // [tls_.data[tls_.bin_to_index[bin]].file_offset,
-                //  tls_.data[tls_.bin_to_index[bin]].file_offset + bin->tls()->p_filesz)
-                *offset_on_got += tls_.data[tls_.bin_to_index[bin]].file_offset;
+            case R_X86_64_GLOB_DAT:
+            case R_X86_64_JUMP_SLOT: {
+                uintptr_t val_or_index;
+                if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
+                    newrel.r_info = ELF_R_INFO(0, R_X86_64_RELATIVE);
+                    newrel.r_addend = val_or_index;
+                } else {
+                    newrel.r_info = ELF_R_INFO(val_or_index, type);
+                }
+                break;
             }
-            break;
+
+            case R_X86_64_64: {
+                uintptr_t val_or_index;
+                if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
+                    newrel.r_info = ELF_R_INFO(0, R_X86_64_RELATIVE);
+                    newrel.r_addend += val_or_index;
+                } else {
+                    newrel.r_info = ELF_R_INFO(val_or_index, type);
+                }
+                break;
+            }
+
+            // TODO(akawashiro) Handle TLS variables in executables.
+            case R_X86_64_DTPMOD64: {
+                // TODO(akawashiro) Refactor out for Arch64
+                const std::string name = bin->Str(sym->st_name);
+                uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+                newrel.r_info = ELF_R_INFO(index, type);
+
+                if (bin->tls() == NULL) {
+                    LOG(INFO) << SOLD_LOG_64BITS(bin->tls()) << " is null. This relocation is TLS generic dynamic model.";
+                    break;
+                }
+
+                uint64_t* mod_on_got =
+                    const_cast<uint64_t*>(reinterpret_cast<const uint64_t*>(bin->head() + bin->OffsetFromAddr(rel->r_offset)));
+                uint64_t* offset_on_got = mod_on_got + 1;
+                const bool is_bss = bin->IsOffsetInTLSBSS(*offset_on_got);
+
+                // We assume dl_tls_index exists in GOT. This struct is used as
+                // the argument of __tls_get_addr.
+                //
+                // typedef struct dl_tls_index
+                // {
+                //   uint64_t ti_module; <--- mod_on_got
+                //   uint64_t ti_offset; <--- offset_on_got
+                // } tls_index;
+                //
+                // In TLS generic dynamic model, both ti_module and ti_offset are
+                // rewritten by R_X86_64_DTPMOD64 and R_X86_64_DTPOFF64,
+                // respectively.
+                //
+                // In TLS local dynamic model, the only ti_module is rewrite by
+                // R_X86_64_DTPMOD64 and ti_offset is fixed in the link process. We
+                // must rewrite the fixed ti_offset because we remap the TLS
+                // template.
+
+                std::vector<int> rewrite_rel_types;  // Type of relocations which rewrite ti_module.
+                for (size_t i = 0; i < bin->num_rels(); ++i) {
+                    if (rel->r_offset + sizeof(uint64_t) <= bin->rel()[i].r_offset &&
+                        bin->rel()[i].r_offset < rel->r_offset + sizeof(uint64_t) + sizeof(uint64_t)) {
+                        rewrite_rel_types.emplace_back(ELF_R_TYPE(bin->rel()[i].r_info));
+                    }
+                }
+
+                CHECK(rewrite_rel_types.size() == 0 || (rewrite_rel_types.size() == 1 && rewrite_rel_types[0] == R_X86_64_DTPOFF64))
+                    << SOLD_LOG_KEY(rewrite_rel_types.size()) << SOLD_LOG_KEY(ShowRelocationType(rewrite_rel_types[0]));
+
+                if (rewrite_rel_types.size() == 1) {
+                    LOG(INFO) << "R_X86_64_DTPOFF64 exists next to R_X86_64_DTPMOD64. This relocation is TLS generic dynamic model.";
+                    break;
+                }
+
+                LOG(INFO) << "R_X86_64_DTPMOD64 relocation in TLS local dynamic model. " << SOLD_LOG_KEY(*rel) << SOLD_LOG_KEY(newrel)
+                          << SOLD_LOG_64BITS(bin->OffsetFromAddr(rel->r_offset)) << SOLD_LOG_64BITS(*mod_on_got)
+                          << SOLD_LOG_64BITS(*offset_on_got) << SOLD_LOG_64BITS(bin->tls()->p_filesz) << SOLD_LOG_KEY(is_bss)
+                          << SOLD_LOG_64BITS(tls_.data[tls_.bin_to_index[bin]].file_offset)
+                          << SOLD_LOG_64BITS(tls_.data[tls_.bin_to_index[bin]].bss_offset);
+
+                // We cannot determine whether the associated symbol is a dummy or
+                // not just using its index. In addition to the traditional dummy
+                // symbol at index 0, I found some compilers emit a dummy symbol at
+                // index 1 of SECTION type.
+                CHECK_EQ(name, "") << "The symbol associated with R_X86_64_DTPMOD64 in TLS local dynamic model should be the dummy."
+                                   << SOLD_LOG_KEY(bin->filename());
+
+                if (is_bss) {
+                    // TLS variables without initial values are remapped from
+                    // [bin->tls()->p_filesz, bin->tls()->p_memsz) to
+                    // [tls_.data[tls_.bin_to_index[bin]].bss_offset,
+                    //  tls_.data[tls_.bin_to_index[bin]].bss_offset + bin->tls()->p_memsz - bin->tls()->p_filesz)
+                    *offset_on_got += tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz;
+                } else {
+                    // TLS variables with initial values are remapped from
+                    // [0, bin->tls()->p_filesz) to
+                    // [tls_.data[tls_.bin_to_index[bin]].file_offset,
+                    //  tls_.data[tls_.bin_to_index[bin]].file_offset + bin->tls()->p_filesz)
+                    *offset_on_got += tls_.data[tls_.bin_to_index[bin]].file_offset;
+                }
+                break;
+            }
+
+            case R_X86_64_DTPOFF64:
+            case R_X86_64_TPOFF64: {
+                const std::string name = bin->Str(sym->st_name);
+                uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+                newrel.r_info = ELF_R_INFO(index, type);
+                LOG(INFO) << ShowRelocationType(type) << " relocation: " << SOLD_LOG_KEY(*rel) << SOLD_LOG_KEY(newrel)
+                          << SOLD_LOG_64BITS(bin->OffsetFromAddr(rel->r_offset));
+                break;
+            }
+
+            case R_X86_64_COPY: {
+                const std::string name = bin->Str(sym->st_name);
+                uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+                newrel.r_info = ELF_R_INFO(index, type);
+                break;
+            }
+
+            default:
+                LOG(FATAL) << "Unknown relocation type: " << ShowRelocationType(type);
+                CHECK(false);
         }
 
-        case R_X86_64_DTPOFF64:
-        case R_X86_64_TPOFF64: {
-            const std::string name = bin->Str(sym->st_name);
-            uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
-            newrel.r_info = ELF_R_INFO(index, type);
-            LOG(INFO) << ShowRelocationType(type) << " relocation: " << SOLD_LOG_KEY(*rel) << SOLD_LOG_KEY(newrel)
-                      << SOLD_LOG_64BITS(bin->OffsetFromAddr(rel->r_offset));
-            break;
-        }
-
-        case R_X86_64_COPY: {
-            const std::string name = bin->Str(sym->st_name);
-            uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
-            newrel.r_info = ELF_R_INFO(index, type);
-            break;
-        }
-
-        default:
-            LOG(FATAL) << "Unknown relocation type: " << ShowRelocationType(type);
-            CHECK(false);
+        rels_.push_back(newrel);
     }
-
-    rels_.push_back(newrel);
 }
 
 // Make new relocation table.
@@ -719,93 +751,121 @@ void Sold::RelocateSymbol_aarch64(ELFBinary* bin, const Elf_Rel* rel, uintptr_t 
 
     int type = ELF_R_TYPE(rel->r_info);
     const uintptr_t addend = rel->r_addend;
-    Elf_Rel newrel = *rel;
+    std::vector<Elf_Rel> newrels;
+
     if (bin->IsVaddrInTLSData(rel->r_offset)) {
+        Elf_Rel newrel = *rel;
         const Elf_Phdr* tls = bin->tls();
         CHECK(tls);
         uintptr_t off = newrel.r_offset - tls->p_vaddr;
         off = RemapTLS("reloc", bin, off);
         newrel.r_offset = off + tls_offset_;
+        newrels.emplace_back(newrel);
     } else {
+        Elf_Rel newrel = *rel;
         newrel.r_offset += offset;
+        newrels.emplace_back(newrel);
+    }
+
+    if (bin->IsAddrInInitarray(rel->r_offset)) {
+        Elf_Rel newrel = *rel;
+        CHECK(bin_to_init_array_offset_.find(bin) != bin_to_init_array_offset_.end()) << SOLD_LOG_KEY(bin->filename());
+
+        newrel.r_offset -= bin->init_array_addr();
+        newrel.r_offset += bin_to_init_array_offset_[bin];
+        LOG(INFO) << SOLD_LOG_BITS(bin->init_array_addr()) << SOLD_LOG_BITS(bin_to_init_array_offset_[bin])
+                  << SOLD_LOG_BITS(newrel.r_offset) << SOLD_LOG_BITS(newrel.r_addend) << SOLD_LOG_BITS(offset);
+        newrels.emplace_back(newrel);
+    } else if (bin->IsAddrInFiniarray(rel->r_offset)) {
+        Elf_Rel newrel = *rel;
+        CHECK(bin_to_fini_array_offset_.find(bin) != bin_to_fini_array_offset_.end()) << SOLD_LOG_KEY(bin->filename());
+
+        newrel.r_offset -= bin->fini_array_addr();
+        newrel.r_offset += bin_to_fini_array_offset_[bin];
+        LOG(INFO) << SOLD_LOG_BITS(bin->fini_array_addr()) << SOLD_LOG_BITS(bin_to_fini_array_offset_[bin])
+                  << SOLD_LOG_BITS(newrel.r_offset) << SOLD_LOG_BITS(newrel.r_addend) << SOLD_LOG_BITS(offset);
+        newrels.emplace_back(newrel);
     }
 
     LOG(INFO) << "Relocate " << bin->Str(sym->st_name) << " at " << rel->r_offset;
 
-    // Even if we found a defined symbol in src_syms_, we cannot
-    // erase the relocation entry. The address needs to be fixed at
-    // runtime by ASLR function so we set RELATIVE to these resolved symbols.
-    switch (type) {
-        case R_AARCH64_RELATIVE: {
-            if (IsDefined(*sym)) {
-                LOG(WARNING) << "The symbol associated with R_AARCH64_RELATIVE is defined. Because this relocation type doesn't need any "
-                                "symbol, something wrong may have happened.";
+    for (auto newrel : newrels) {
+        // Even if we found a defined symbol in src_syms_, we cannot
+        // erase the relocation entry. The address needs to be fixed at
+        // runtime by ASLR function so we set RELATIVE to these resolved symbols.
+        switch (type) {
+            case R_AARCH64_RELATIVE: {
+                if (IsDefined(*sym)) {
+                    LOG(WARNING)
+                        << "The symbol associated with R_AARCH64_RELATIVE is defined. Because this relocation type doesn't need any "
+                           "symbol, something wrong may have happened.";
+                }
+                newrel.r_addend += offset;
+                break;
             }
-            newrel.r_addend += offset;
-            break;
-        }
 
-        case R_AARCH64_GLOB_DAT:
-        case R_AARCH64_JUMP_SLOT: {
-            uintptr_t val_or_index;
-            if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
-                newrel.r_info = ELF_R_INFO(0, R_AARCH64_RELATIVE);
-                newrel.r_addend = val_or_index;
-            } else {
-                newrel.r_info = ELF_R_INFO(val_or_index, type);
-            }
-            break;
-        }
-
-        case R_AARCH64_ABS64: {
-            uintptr_t val_or_index;
-            if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
-                newrel.r_info = ELF_R_INFO(0, R_AARCH64_RELATIVE);
-                newrel.r_addend += val_or_index;
-            } else {
-                newrel.r_info = ELF_R_INFO(val_or_index, type);
-            }
-            break;
-        }
-
-        case R_AARCH64_TLSDESC: {
-            const std::string name = bin->Str(sym->st_name);
-            if (name == "") {
-                LOG(INFO) << SOLD_LOG_KEY(name) << "R_AARCH64_TLSDESC in local dynamic";
-                uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
-                newrel.r_info = ELF_R_INFO(index, type);
-                const bool is_bss = bin->IsOffsetInTLSBSS(newrel.r_addend);
-                if (is_bss) {
-                    LOG(INFO) << "R_AARCH64_TLSDESC" << SOLD_LOG_BITS(newrel.r_addend)
-                              << SOLD_LOG_BITS(tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz);
-                    newrel.r_addend += tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz;
+            case R_AARCH64_GLOB_DAT:
+            case R_AARCH64_JUMP_SLOT: {
+                uintptr_t val_or_index;
+                if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
+                    newrel.r_info = ELF_R_INFO(0, R_AARCH64_RELATIVE);
+                    newrel.r_addend = val_or_index;
                 } else {
-                    LOG(INFO) << "R_AARCH64_TLSDESC" << SOLD_LOG_BITS(newrel.r_addend)
-                              << SOLD_LOG_BITS(tls_.data[tls_.bin_to_index[bin]].file_offset);
-                    newrel.r_addend += tls_.data[tls_.bin_to_index[bin]].file_offset;
+                    newrel.r_info = ELF_R_INFO(val_or_index, type);
                 }
                 break;
-            } else {
-                LOG(INFO) << SOLD_LOG_KEY(name) << "R_AARCH64_TLSDESC in generic dynamic";
+            }
+
+            case R_AARCH64_ABS64: {
+                uintptr_t val_or_index;
+                if (syms_.Resolve(bin->Str(sym->st_name), soname, version_name, val_or_index)) {
+                    newrel.r_info = ELF_R_INFO(0, R_AARCH64_RELATIVE);
+                    newrel.r_addend += val_or_index;
+                } else {
+                    newrel.r_info = ELF_R_INFO(val_or_index, type);
+                }
+                break;
+            }
+
+            case R_AARCH64_TLSDESC: {
+                const std::string name = bin->Str(sym->st_name);
+                if (name == "") {
+                    LOG(INFO) << SOLD_LOG_KEY(name) << "R_AARCH64_TLSDESC in local dynamic";
+                    uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+                    newrel.r_info = ELF_R_INFO(index, type);
+                    const bool is_bss = bin->IsOffsetInTLSBSS(newrel.r_addend);
+                    if (is_bss) {
+                        LOG(INFO) << "R_AARCH64_TLSDESC" << SOLD_LOG_BITS(newrel.r_addend)
+                                  << SOLD_LOG_BITS(tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz);
+                        newrel.r_addend += tls_.data[tls_.bin_to_index[bin]].bss_offset - bin->tls()->p_filesz;
+                    } else {
+                        LOG(INFO) << "R_AARCH64_TLSDESC" << SOLD_LOG_BITS(newrel.r_addend)
+                                  << SOLD_LOG_BITS(tls_.data[tls_.bin_to_index[bin]].file_offset);
+                        newrel.r_addend += tls_.data[tls_.bin_to_index[bin]].file_offset;
+                    }
+                    break;
+                } else {
+                    LOG(INFO) << SOLD_LOG_KEY(name) << "R_AARCH64_TLSDESC in generic dynamic";
+                    uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
+                    newrel.r_info = ELF_R_INFO(index, type);
+                    break;
+                }
+            }
+
+            case R_AARCH64_COPY: {
+                const std::string name = bin->Str(sym->st_name);
                 uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
                 newrel.r_info = ELF_R_INFO(index, type);
                 break;
             }
+
+            default:
+                LOG(FATAL) << "Unknown relocation type: " << ShowRelocationType(type);
+                CHECK(false);
         }
 
-        case R_AARCH64_COPY: {
-            const std::string name = bin->Str(sym->st_name);
-            uintptr_t index = syms_.ResolveCopy(name, soname, version_name);
-            newrel.r_info = ELF_R_INFO(index, type);
-            break;
-        }
-
-        default:
-            LOG(FATAL) << "Unknown relocation type: " << ShowRelocationType(type);
-            CHECK(false);
+        rels_.push_back(newrel);
     }
-
-    rels_.push_back(newrel);
 }
 
 std::string Sold::ResolveRunPathVariables(const ELFBinary* binary, const std::string& runpath) {

--- a/sold.cc
+++ b/sold.cc
@@ -98,12 +98,12 @@ void Sold::Emit(const std::string& out_filename) {
     CHECK(fp);
     Write(fp, ehdr_);
     EmitPhdrs(fp);
+    EmitArrays(fp);
     EmitGnuHash(fp);
     EmitSymtab(fp);
     EmitVersym(fp);
     EmitVerneed(fp);
     EmitRel(fp);
-    EmitArrays(fp);
     EmitStrtab(fp);
     EmitDynamic(fp);
     EmitShstrtab(fp);

--- a/sold.h
+++ b/sold.h
@@ -64,7 +64,15 @@ private:
         return num_phdrs;
     }
 
-    uintptr_t GnuHashOffset() const { return sizeof(Elf_Ehdr) + sizeof(Elf_Phdr) * CountPhdrs(); }
+    // We emit .init_array and .fini_array at the head of ELF file.
+    // This is because we want to fix the addresses of arrays as much as possible to emit relocation entries easily.
+    uintptr_t InitArrayOffset() const { return AlignNext(sizeof(Elf_Ehdr) + sizeof(Elf_Phdr) * CountPhdrs(), 7); }
+    uintptr_t InitArraySize() const { return sizeof(uintptr_t) * init_array_.size(); }
+
+    uintptr_t FiniArrayOffset() const { return InitArrayOffset() + InitArraySize(); }
+    uintptr_t FiniArraySize() const { return sizeof(uintptr_t) * fini_array_.size(); }
+
+    uintptr_t GnuHashOffset() const { return FiniArrayOffset() + FiniArraySize(); }
     uintptr_t GnuHashSize() const { return syms_.GnuHashSize(); }
 
     uintptr_t SymtabOffset() const { return GnuHashOffset() + GnuHashSize(); }
@@ -79,13 +87,7 @@ private:
     uintptr_t RelOffset() const { return VerneedOffset() + VerneedSize(); }
     uintptr_t RelSize() const { return rels_.size() * sizeof(Elf_Rel); }
 
-    uintptr_t InitArrayOffset() const { return AlignNext(RelOffset() + RelSize(), 7); }
-    uintptr_t InitArraySize() const { return sizeof(uintptr_t) * init_array_.size(); }
-
-    uintptr_t FiniArrayOffset() const { return InitArrayOffset() + InitArraySize(); }
-    uintptr_t FiniArraySize() const { return sizeof(uintptr_t) * fini_array_.size(); }
-
-    uintptr_t StrtabOffset() const { return FiniArrayOffset() + FiniArraySize(); }
+    uintptr_t StrtabOffset() const { return RelOffset() + RelSize(); }
     uintptr_t StrtabSize() const { return strtab_.size(); }
 
     uintptr_t DynamicOffset() const { return StrtabOffset() + StrtabSize(); }

--- a/sold.h
+++ b/sold.h
@@ -467,5 +467,7 @@ private:
     std::vector<Elf_Dyn> dynamic_;
     std::vector<uintptr_t> init_array_;
     std::vector<uintptr_t> fini_array_;
+    std::map<ELFBinary*, uintptr_t> bin_to_init_array_offset_;
+    std::map<ELFBinary*, uintptr_t> bin_to_fini_array_offset_;
     TLS tls_;
 };


### PR DESCRIPTION
This PR fixes bugs of `.init_array` and `.fini_array`.

We have emitted relocations of `R_X64_64_RELATIVE` or `R_AARCH64_RELATIVE` for all entries in arrays. But it is not appropriate when the original shared objects use relocations other than `R_*_RELATIVE`. For example, `liblapack.so.3` uses `R_AARCH64_ABS64` as discussed in Slack.

I stopped emitting `R_*_RELATIVE` relocations unconditionally and re-use relocations of the original shared objects to resolve this bug. I implemented this just as same as TLS ones. `Sold` class records mappings from `Elf_binary*` to new offsets of arrays in https://github.com/shinh/sold/commit/44cd940d7148179929b792d3a0bbf2abea3b1598 and remap relocations using the mappings in https://github.com/shinh/sold/commit/e51d6a7c292045ae0615132ada9910ea12189535.

In addition to remap relocations, https://github.com/shinh/sold/commit/e51d6a7c292045ae0615132ada9910ea12189535 duplicates relocations in arrays because arrays are embedded in `PT_LOAD`, so we must emit relocations for parts of `PT_LOAD` which original relocations rewrite.

I think this PR fixes all bugs around arrays so that I can remove existing workarounds (https://github.com/shinh/sold/commit/02931a9a1293ffb627fe0e4cfa38e0ffaa73edd3).